### PR TITLE
Add Chainlink Oracle

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -6,14 +6,12 @@ import "./_external/Ownable.sol";
 import "./lib/SafeMathInt.sol";
 import "./lib/UInt256Lib.sol";
 
+import "./interfaces/IOracle.sol";
+
 interface IUFragments {
     function totalSupply() external view returns (uint256);
 
     function rebase(uint256 epoch, int256 supplyDelta) external returns (uint256);
-}
-
-interface IOracle {
-    function getData() external returns (uint256, bool);
 }
 
 /**

--- a/contracts/interfaces/IChainlinkAggregator.sol
+++ b/contracts/interfaces/IChainlinkAggregator.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.7.6;
+
+interface IChainlinkAggregator {
+    function latestAnswer() external view returns (uint256);
+}

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.7.6;
+
+interface IOracle {
+    function getData() external returns (uint256, bool);
+}

--- a/contracts/mocks/MockChainlinkAggregator.sol
+++ b/contracts/mocks/MockChainlinkAggregator.sol
@@ -1,0 +1,24 @@
+import "../interfaces/IChainlinkAggregator.sol";
+
+/**
+ * @title Chainlink Oracle
+ *
+ * @notice Provides a value onchain from a chainlink oracle aggregator
+ */
+contract MockChainlinkAggregator is IChainlinkAggregator {
+    uint256 public answer;
+
+    /**
+     * Get the latest answer from the oracle
+     */
+    function latestAnswer() external view override returns (uint256) {
+        return answer;
+    }
+
+    /**
+     * Set the latest answer to be returned from now on
+     */
+    function setLatestAnswer(uint256 _answer) public {
+        answer = _answer;
+    }
+}

--- a/contracts/mocks/MockOracleDataFetcher.sol
+++ b/contracts/mocks/MockOracleDataFetcher.sol
@@ -1,0 +1,32 @@
+import "../interfaces/IOracle.sol";
+
+/**
+ * @title Mock oracle data fetcher
+ *
+ * @notice Fetches data from an oracle
+ */
+contract MockOracleDataFetcher {
+    IOracle public oracle;
+    uint256 public data;
+    bool public success;
+
+    constructor(address _oracle) {
+        oracle = IOracle(_oracle);
+    }
+
+    /**
+     * Return the latest answer from the oracle
+     */
+    function getData() external view returns (uint256, bool) {
+        return (data, success);
+    }
+
+    /**
+     * Fetch the latest answer from the oracle
+     */
+    function fetch() external {
+        (uint256 _data, bool _success) = oracle.getData();
+        data = _data;
+        success = _success;
+    }
+}

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.7.6;
+
+import "../interfaces/IOracle.sol";
+import "../interfaces/IChainlinkAggregator.sol";
+
+/**
+ * @title Chainlink Oracle
+ *
+ * @notice Provides a value onchain from a chainlink oracle aggregator
+ */
+contract ChainlinkOracle is IOracle {
+    // The address of the Chainlink Aggregator contract
+    IChainlinkAggregator public oracle;
+
+    constructor(address _oracle) public {
+        oracle = IChainlinkAggregator(_oracle);
+    }
+
+    /**
+     * @notice Fetches the latest market price from chainlink
+     * @return Value: Latest market price.
+     *         valid: Boolean indicating an value was fetched successfully.
+     */
+    function getData() external override returns (uint256, bool) {
+        uint256 result = oracle.latestAnswer();
+        return (result, true);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,7 +3,7 @@ import { HardhatUserConfig } from 'hardhat/config'
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 import '@openzeppelin/hardhat-upgrades'
-import "@nomiclabs/hardhat-etherscan";
+import '@nomiclabs/hardhat-etherscan'
 import 'solidity-coverage'
 import 'hardhat-gas-reporter'
 
@@ -11,18 +11,18 @@ require('./scripts/deploy')
 
 export default {
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY
+    apiKey: process.env.ETHERSCAN_API_KEY,
   },
   networks: {
     rinkeby: {
-      url: `https://rinkeby.infura.io/v3/${process.env.INFURA_SECRET}`
+      url: `https://rinkeby.infura.io/v3/${process.env.INFURA_SECRET}`,
     },
     kovan: {
-      url: `https://kovan.infura.io/v3/${process.env.INFURA_SECRET}`
+      url: `https://kovan.infura.io/v3/${process.env.INFURA_SECRET}`,
     },
     mainnet: {
-      url: `https://mainnet.infura.io/v3/${process.env.INFURA_SECRET}`
-    }
+      url: `https://mainnet.infura.io/v3/${process.env.INFURA_SECRET}`,
+    },
   },
   solidity: {
     compilers: [

--- a/test/unit/ChainlinkOracle.ts
+++ b/test/unit/ChainlinkOracle.ts
@@ -1,0 +1,72 @@
+import { ethers, waffle } from 'hardhat'
+import { Contract, Signer } from 'ethers'
+import { increaseTime } from '../utils/utils'
+import { expect } from 'chai'
+import { TransactionResponse } from '@ethersproject/providers'
+
+let oracle: Contract, mockAggregator: Contract, oracleFetcher: Contract
+let r: Promise<TransactionResponse>
+let deployer: Signer, user: Signer
+
+async function mockedOracle() {
+  const [deployer, user] = await ethers.getSigners()
+  // deploy mocks
+  const mockAggregator = await (
+    await ethers.getContractFactory('MockChainlinkAggregator')
+  )
+    .connect(deployer)
+    .deploy()
+  const oracle = await (await ethers.getContractFactory('ChainlinkOracle'))
+    .connect(deployer)
+    .deploy(mockAggregator.address)
+
+  const oracleFetcher = await (
+    await ethers.getContractFactory('MockOracleDataFetcher')
+  )
+    .connect(deployer)
+    .deploy(oracle.address)
+  return {
+    deployer,
+    user,
+    oracle,
+    oracleFetcher,
+    mockAggregator,
+  }
+}
+
+describe('ChainlinkOracle', function () {
+  before('setup Orchestrator contract', async () => {
+    ;({
+      deployer,
+      user,
+      oracle,
+      oracleFetcher,
+      mockAggregator,
+    } = await waffle.loadFixture(mockedOracle))
+  })
+
+  describe('when sent ether', async function () {
+    it('should reject', async function () {
+      await expect(user.sendTransaction({ to: oracle.address, value: 1 })).to.be
+        .reverted
+    })
+  })
+
+  describe('Fetching data', async function () {
+    it('should fetch data', async function () {
+      const data = ethers.BigNumber.from('18923491321')
+
+      await expect(mockAggregator.connect(user).setLatestAnswer(data)).to.not.be
+        .reverted
+
+      // we use an oracle fetcher contract because, since the IOracle
+      // interface getData function is writable, we can't fetch the response directly
+      await oracleFetcher.connect(user).fetch()
+
+      const [res, success] = await oracleFetcher.getData()
+
+      expect(res.toString()).to.eq(data.toString())
+      expect(success).to.eq(true)
+    })
+  })
+})


### PR DESCRIPTION
This commit adds a new oracle implementation that acts as an adapter for
a chainlink aggregator. This will facilitate the buttonToken rebasing
wrapper implementation