### PR TITLE
Add ButtonToken rebase functionality

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -2,6 +2,7 @@ pragma solidity 0.7.6;
 
 import "./_external/SafeMath.sol";
 import "./_external/Ownable.sol";
+import "./_external/IERC20.sol";
 
 import "./lib/SafeMathInt.sol";
 import "./lib/UInt256Lib.sol";
@@ -11,7 +12,7 @@ import "./interfaces/IOracle.sol";
 interface IUFragments {
     function totalSupply() external view returns (uint256);
 
-    function rebase(uint256 epoch, int256 supplyDelta) external returns (uint256);
+    function rebase(uint256 newSupply) external returns (uint256);
 }
 
 /**
@@ -28,126 +29,38 @@ contract UFragmentsPolicy is Ownable {
     using SafeMathInt for int256;
     using UInt256Lib for uint256;
 
-    event LogRebase(
-        uint256 indexed epoch,
-        uint256 exchangeRate,
-        uint256 cpi,
-        int256 requestedSupplyAdjustment,
-        uint256 timestampSec
-    );
+    event LogRebase(uint256 exchangeRate, uint256 newSupply);
 
     IUFragments public uFrags;
+    IERC20 public collateralToken;
 
-    // Provides the current CPI, as an 18 decimal fixed point number.
-    IOracle public cpiOracle;
-
-    // Market oracle provides the token/USD exchange rate as an 18 decimal fixed point number.
-    // (eg) An oracle value of 1.5e18 it would mean 1 Ample is trading for $1.50.
+    // Market oracle provides the token/USD exchange rate as an 8 decimal fixed point number.
+    // (eg) An oracle value of 1.5e8 it would mean 1 unit of collateral is trading for $1.50.
     IOracle public marketOracle;
 
-    // CPI value at the time of launch, as an 18 decimal fixed point number.
-    uint256 private baseCpi;
-
-    // If the current exchange rate is within this fractional distance from the target, no supply
-    // update is performed. Fixed point number--same format as the rate.
-    // (ie) abs(rate - targetRate) / targetRate < deviationThreshold, then no supply change.
-    // DECIMALS Fixed point number.
-    uint256 public deviationThreshold;
-
-    // The rebase lag parameter, used to dampen the applied supply adjustment by 1 / rebaseLag
-    // Check setRebaseLag comments for more details.
-    // Natural number, no decimal places.
-    uint256 public rebaseLag;
-
-    // More than this much time must pass between rebase operations.
-    uint256 public minRebaseTimeIntervalSec;
-
-    // Block timestamp of last rebase operation
-    uint256 public lastRebaseTimestampSec;
-
-    // The rebase window begins this many seconds into the minRebaseTimeInterval period.
-    // For example if minRebaseTimeInterval is 24hrs, it represents the time of day in seconds.
-    uint256 public rebaseWindowOffsetSec;
-
-    // The length of the time window where a rebase operation is allowed to execute, in seconds.
-    uint256 public rebaseWindowLengthSec;
-
-    // The number of rebase cycles since inception
-    uint256 public epoch;
-
-    uint256 private constant DECIMALS = 18;
-
-    // Due to the expression in computeSupplyDelta(), MAX_RATE * MAX_SUPPLY must fit into an int256.
-    // Both are 18 decimals fixed point numbers.
-    uint256 private constant MAX_RATE = 10**6 * 10**DECIMALS;
-    // MAX_SUPPLY = MAX_INT256 / MAX_RATE
-    uint256 private constant MAX_SUPPLY = uint256(type(int256).max) / MAX_RATE;
-
-    // This module orchestrates the rebase execution and downstream notification.
-    address public orchestrator;
-
-    modifier onlyOrchestrator() {
-        require(msg.sender == orchestrator);
-        _;
-    }
+    uint256 private constant EXCHANGE_RATE_DECIMALS = 8;
 
     /**
-     * @notice Initiates a new rebase operation, provided the minimum time period has elapsed.
+     * @notice Initiates a new rebase operation.
      *
-     * @dev The supply adjustment equals (_totalSupply * DeviationFromTargetRate) / rebaseLag
-     *      Where DeviationFromTargetRate is (MarketOracleRate - targetRate) / targetRate
-     *      and targetRate is CpiOracleRate / baseCpi
+     * @dev The new supply equals (exchangeRate * collateralBalance)
      */
-    function rebase() external onlyOrchestrator {
-        require(inRebaseWindow());
-
-        // This comparison also ensures there is no reentrancy.
-        require(lastRebaseTimestampSec.add(minRebaseTimeIntervalSec) < block.timestamp);
-
-        // Snap the rebase time to the start of this window.
-        lastRebaseTimestampSec = block
-            .timestamp
-            .sub(block.timestamp.mod(minRebaseTimeIntervalSec))
-            .add(rebaseWindowOffsetSec);
-
-        epoch = epoch.add(1);
-
-        uint256 cpi;
-        bool cpiValid;
-        (cpi, cpiValid) = cpiOracle.getData();
-        require(cpiValid);
-
-        uint256 targetRate = cpi.mul(10**DECIMALS).div(baseCpi);
-
+    function rebase() external {
         uint256 exchangeRate;
         bool rateValid;
         (exchangeRate, rateValid) = marketOracle.getData();
-        require(rateValid);
+        require(rateValid, "Invalid rate");
 
-        if (exchangeRate > MAX_RATE) {
-            exchangeRate = MAX_RATE;
-        }
+        uint256 newSupply = computeNewSupply(exchangeRate);
 
-        int256 supplyDelta = computeSupplyDelta(exchangeRate, targetRate);
-
-        // Apply the Dampening factor.
-        supplyDelta = supplyDelta.div(rebaseLag.toInt256Safe());
-
-        if (supplyDelta > 0 && uFrags.totalSupply().add(uint256(supplyDelta)) > MAX_SUPPLY) {
-            supplyDelta = (MAX_SUPPLY.sub(uFrags.totalSupply())).toInt256Safe();
-        }
-
-        uint256 supplyAfterRebase = uFrags.rebase(epoch, supplyDelta);
-        assert(supplyAfterRebase <= MAX_SUPPLY);
-        emit LogRebase(epoch, exchangeRate, cpi, supplyDelta, block.timestamp);
-    }
-
-    /**
-     * @notice Sets the reference to the CPI oracle.
-     * @param cpiOracle_ The address of the cpi oracle contract.
-     */
-    function setCpiOracle(IOracle cpiOracle_) external onlyOwner {
-        cpiOracle = cpiOracle_;
+        uint256 supplyAfterRebase = uFrags.rebase(newSupply);
+        // the actual rebase can result in a lower supply than requested
+        // to satisfy maximum supply constraint in uFrags - but should never be higher.
+        // Note this means that if we exceed the maximum supply constraint, the unit token value
+        // will not properly rebase to $1 and collateral should be removed.
+        // however this value is 2^128 units, which is over ~$3e20 worth of collateral
+        require(supplyAfterRebase <= newSupply, "Invalid supply");
+        emit LogRebase(exchangeRate, newSupply);
     }
 
     /**
@@ -159,142 +72,28 @@ contract UFragmentsPolicy is Ownable {
     }
 
     /**
-     * @notice Sets the reference to the orchestrator.
-     * @param orchestrator_ The address of the orchestrator contract.
-     */
-    function setOrchestrator(address orchestrator_) external onlyOwner {
-        orchestrator = orchestrator_;
-    }
-
-    /**
-     * @notice Sets the deviation threshold fraction. If the exchange rate given by the market
-     *         oracle is within this fractional distance from the targetRate, then no supply
-     *         modifications are made. DECIMALS fixed point number.
-     * @param deviationThreshold_ The new exchange rate threshold fraction.
-     */
-    function setDeviationThreshold(uint256 deviationThreshold_) external onlyOwner {
-        deviationThreshold = deviationThreshold_;
-    }
-
-    /**
-     * @notice Sets the rebase lag parameter.
-               It is used to dampen the applied supply adjustment by 1 / rebaseLag
-               If the rebase lag R, equals 1, the smallest value for R, then the full supply
-               correction is applied on each rebase cycle.
-               If it is greater than 1, then a correction of 1/R of is applied on each rebase.
-     * @param rebaseLag_ The new rebase lag parameter.
-     */
-    function setRebaseLag(uint256 rebaseLag_) external onlyOwner {
-        require(rebaseLag_ > 0);
-        rebaseLag = rebaseLag_;
-    }
-
-    /**
-     * @notice Sets the parameters which control the timing and frequency of
-     *         rebase operations.
-     *         a) the minimum time period that must elapse between rebase cycles.
-     *         b) the rebase window offset parameter.
-     *         c) the rebase window length parameter.
-     * @param minRebaseTimeIntervalSec_ More than this much time must pass between rebase
-     *        operations, in seconds.
-     * @param rebaseWindowOffsetSec_ The number of seconds from the beginning of
-              the rebase interval, where the rebase window begins.
-     * @param rebaseWindowLengthSec_ The length of the rebase window in seconds.
-     */
-    function setRebaseTimingParameters(
-        uint256 minRebaseTimeIntervalSec_,
-        uint256 rebaseWindowOffsetSec_,
-        uint256 rebaseWindowLengthSec_
-    ) external onlyOwner {
-        require(minRebaseTimeIntervalSec_ > 0);
-        require(rebaseWindowOffsetSec_ < minRebaseTimeIntervalSec_);
-
-        minRebaseTimeIntervalSec = minRebaseTimeIntervalSec_;
-        rebaseWindowOffsetSec = rebaseWindowOffsetSec_;
-        rebaseWindowLengthSec = rebaseWindowLengthSec_;
-    }
-
-    /**
-     * @notice A multi-chain AMPL interface method. The Ampleforth monetary policy contract
-     *         on the base-chain and XC-AmpleController contracts on the satellite-chains
-     *         implement this method. It atomically returns two values:
-     *         what the current contract believes to be,
-     *         the globalAmpleforthEpoch and globalAMPLSupply.
-     * @return globalAmpleforthEpoch The current epoch number.
-     * @return globalAMPLSupply The total supply at the current epoch.
-     */
-    function globalAmpleforthEpochAndAMPLSupply() external view returns (uint256, uint256) {
-        return (epoch, uFrags.totalSupply());
-    }
-
-    /**
      * @dev ZOS upgradable contract initialization method.
      *      It is called at the time of contract creation to invoke parent class initializers and
      *      initialize the contract's state variables.
      */
     function initialize(
-        address owner_,
-        IUFragments uFrags_,
-        uint256 baseCpi_
+        address _owner,
+        IUFragments _uFrags,
+        IERC20 _collateralToken
     ) public initializer {
-        Ownable.initialize(owner_);
+        Ownable.initialize(_owner);
 
-        // deviationThreshold = 0.05e18 = 5e16
-        deviationThreshold = 5 * 10**(DECIMALS - 2);
-
-        rebaseLag = 30;
-        minRebaseTimeIntervalSec = 1 days;
-        rebaseWindowOffsetSec = 72000; // 8PM UTC
-        rebaseWindowLengthSec = 15 minutes;
-        lastRebaseTimestampSec = 0;
-        epoch = 0;
-
-        uFrags = uFrags_;
-        baseCpi = baseCpi_;
+        uFrags = _uFrags;
+        collateralToken = _collateralToken;
     }
 
     /**
-     * @return If the latest block timestamp is within the rebase time window it, returns true.
-     *         Otherwise, returns false.
-     */
-    function inRebaseWindow() public view returns (bool) {
-        return (block.timestamp.mod(minRebaseTimeIntervalSec) >= rebaseWindowOffsetSec &&
-            block.timestamp.mod(minRebaseTimeIntervalSec) <
-            (rebaseWindowOffsetSec.add(rebaseWindowLengthSec)));
-    }
-
-    /**
-     * @return Computes the total supply adjustment in response to the exchange rate
+     * @return Computes the new total supply in response to the exchange rate
      *         and the targetRate.
      */
-    function computeSupplyDelta(uint256 rate, uint256 targetRate) internal view returns (int256) {
-        if (withinDeviationThreshold(rate, targetRate)) {
-            return 0;
-        }
-
-        // supplyDelta = totalSupply * (rate - targetRate) / targetRate
-        int256 targetRateSigned = targetRate.toInt256Safe();
-        return
-            uFrags.totalSupply().toInt256Safe().mul(rate.toInt256Safe().sub(targetRateSigned)).div(
-                targetRateSigned
-            );
-    }
-
-    /**
-     * @param rate The current exchange rate, an 18 decimal fixed point number.
-     * @param targetRate The target exchange rate, an 18 decimal fixed point number.
-     * @return If the rate is within the deviation threshold from the target rate, returns true.
-     *         Otherwise, returns false.
-     */
-    function withinDeviationThreshold(uint256 rate, uint256 targetRate)
-        internal
-        view
-        returns (bool)
-    {
-        uint256 absoluteDeviationThreshold = targetRate.mul(deviationThreshold).div(10**DECIMALS);
-
-        return
-            (rate >= targetRate && rate.sub(targetRate) < absoluteDeviationThreshold) ||
-            (rate < targetRate && targetRate.sub(rate) < absoluteDeviationThreshold);
+    function computeNewSupply(uint256 exchangeRate) internal view returns (uint256) {
+        uint256 collateralBalance = collateralToken.balanceOf(address(this));
+        // newSupply is the total value of the collateral = (exchange rate * collateral balance)
+        return exchangeRate.mul(collateralBalance).div(10**EXCHANGE_RATE_DECIMALS);
     }
 }

--- a/contracts/mocks/MockChainlinkAggregator.sol
+++ b/contracts/mocks/MockChainlinkAggregator.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.7.6;
+
 import "../interfaces/IChainlinkAggregator.sol";
 
 /**

--- a/contracts/mocks/MockERC20Token.sol
+++ b/contracts/mocks/MockERC20Token.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.7.6;
+
+import "./Mock.sol";
+
+contract MockERC20Token is Mock {
+    uint256 private _supply;
+    uint256 private _balance;
+
+    // Methods to mock data on the chain
+    function storeSupply(uint256 supply) public {
+        _supply = supply;
+    }
+
+    // Methods to mock data on the chain
+    function storeBalance(uint256 balance) public {
+        _balance = balance;
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _supply;
+    }
+
+    function balanceOf(address who) public view returns (uint256) {
+        return _balance;
+    }
+}

--- a/contracts/mocks/MockOracleDataFetcher.sol
+++ b/contracts/mocks/MockOracleDataFetcher.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.7.6;
+
 import "../interfaces/IOracle.sol";
 
 /**

--- a/contracts/mocks/MockUFragments.sol
+++ b/contracts/mocks/MockUFragments.sol
@@ -11,14 +11,13 @@ contract MockUFragments is Mock {
     }
 
     // Mock methods
-    function rebase(uint256 epoch, int256 supplyDelta) public returns (uint256) {
+    function rebase(uint256 newSupply) public returns (uint256) {
         emit FunctionCalled("UFragments", "rebase", msg.sender);
         uint256[] memory uintVals = new uint256[](1);
-        uintVals[0] = epoch;
-        int256[] memory intVals = new int256[](1);
-        intVals[0] = supplyDelta;
+        uintVals[0] = newSupply;
+        int256[] memory intVals = new int256[](0);
         emit FunctionArguments(uintVals, intVals);
-        return uint256(int256(_supply) + int256(supplyDelta));
+        return newSupply;
     }
 
     function totalSupply() public view returns (uint256) {

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -18,7 +18,7 @@ contract ChainlinkOracle is IOracle {
 
     /**
      * @notice Fetches the latest market price from chainlink
-     * @return Value: Latest market price.
+     * @return Value: Latest market price as an 8 decimal fixed point number.
      *         valid: Boolean indicating an value was fetched successfully.
      */
     function getData() external override returns (uint256, bool) {

--- a/test/simulation/supply_precision.ts
+++ b/test/simulation/supply_precision.ts
@@ -30,7 +30,7 @@ async function exec() {
     console.log('Iteration', i + 1)
 
     preRebaseSupply = await uFragments.totalSupply()
-    await uFragments.connect(deployer).rebase(2 * i, 1)
+    await uFragments.connect(deployer).rebase(preRebaseSupply.add(1))
     postRebaseSupply = await uFragments.totalSupply()
     console.log('Rebased by 1 AMPL')
     console.log('Total supply is now', postRebaseSupply.toString(), 'AMPL')
@@ -39,7 +39,7 @@ async function exec() {
     expect(postRebaseSupply.sub(preRebaseSupply).toNumber()).to.eq(1)
 
     console.log('Doubling supply')
-    await uFragments.connect(deployer).rebase(2 * i + 1, postRebaseSupply)
+    await uFragments.connect(deployer).rebase(postRebaseSupply.mul(2))
     i++
   } while ((await uFragments.totalSupply()).lt(endSupply))
 }

--- a/test/simulation/transfer_precision.ts
+++ b/test/simulation/transfer_precision.ts
@@ -80,7 +80,8 @@ async function exec() {
 
   let i = 0
   do {
-    await uFragments.connect(deployer).rebase(i + 1, rebaseAmt)
+    preRebaseSupply = await uFragments.totalSupply()
+    await uFragments.connect(deployer).rebase(preRebaseSupply.add(rebaseAmt))
     postRebaseSupply = await uFragments.totalSupply()
     i++
 

--- a/test/unit/UFragments.ts
+++ b/test/unit/UFragments.ts
@@ -129,13 +129,16 @@ describe('UFragments:Rebase:accessControl', async () => {
   })
 
   it('should be callable by monetary policy', async function () {
-    await expect(uFragments.connect(user).rebase(1, transferAmount)).to.not.be
-      .reverted
+    const supply = await uFragments.totalSupply()
+    await expect(uFragments.connect(user).rebase(supply.add(transferAmount))).to
+      .not.be.reverted
   })
 
   it('should not be callable by others', async function () {
-    await expect(uFragments.connect(deployer).rebase(1, transferAmount)).to.be
-      .reverted
+    const supply = await uFragments.totalSupply()
+    await expect(
+      uFragments.connect(deployer).rebase(supply.add(transferAmount)),
+    ).to.be.reverted
   })
 })
 
@@ -177,9 +180,10 @@ describe('UFragments:Rebase:Expansion', async () => {
   })
 
   it('should emit Rebase', async function () {
-    await expect(uFragments.connect(policy).rebase(1, rebaseAmt))
+    const supply = await uFragments.totalSupply()
+    await expect(uFragments.connect(policy).rebase(supply.add(rebaseAmt)))
       .to.emit(uFragments, 'LogRebase')
-      .withArgs(1, initialSupply.add(rebaseAmt))
+      .withArgs(initialSupply.add(rebaseAmt))
   })
 
   it('should increase the totalSupply', async function () {
@@ -209,10 +213,11 @@ describe('UFragments:Rebase:Expansion', async () => {
   })
 
   it('should return the new supply', async function () {
+    const supply = await uFragments.totalSupply()
     const returnVal = await uFragments
       .connect(policy)
-      .callStatic.rebase(2, rebaseAmt)
-    await uFragments.connect(policy).rebase(2, rebaseAmt)
+      .callStatic.rebase(supply.add(rebaseAmt))
+    await uFragments.connect(policy).rebase(supply.add(rebaseAmt))
     expect(await uFragments.totalSupply()).to.eq(returnVal)
   })
 })
@@ -231,15 +236,16 @@ describe('UFragments:Rebase:Expansion', async function () {
       const totalSupply = await uFragments.totalSupply.call()
       await uFragments
         .connect(policy)
-        .rebase(1, MAX_SUPPLY.sub(totalSupply).sub(toUFrgDenomination('1')))
+        .rebase(MAX_SUPPLY.sub(toUFrgDenomination('1')))
     })
 
     it('should emit Rebase', async function () {
+      const supply = await uFragments.totalSupply()
       await expect(
-        uFragments.connect(policy).rebase(2, toUFrgDenomination('2')),
+        uFragments.connect(policy).rebase(supply.add(toUFrgDenomination('2'))),
       )
         .to.emit(uFragments, 'LogRebase')
-        .withArgs(2, MAX_SUPPLY)
+        .withArgs(MAX_SUPPLY)
     })
 
     it('should increase the totalSupply to MAX_SUPPLY', async function () {
@@ -253,11 +259,12 @@ describe('UFragments:Rebase:Expansion', async function () {
     })
 
     it('should emit Rebase', async function () {
+      const supply = await uFragments.totalSupply()
       await expect(
-        uFragments.connect(policy).rebase(3, toUFrgDenomination('2')),
+        uFragments.connect(policy).rebase(supply.add(toUFrgDenomination('2'))),
       )
         .to.emit(uFragments, 'LogRebase')
-        .withArgs(3, MAX_SUPPLY)
+        .withArgs(MAX_SUPPLY)
     })
 
     it('should NOT change the totalSupply', async function () {
@@ -303,9 +310,10 @@ describe('UFragments:Rebase:NoChange', function () {
   })
 
   it('should emit Rebase', async function () {
-    await expect(uFragments.connect(policy).rebase(1, 0))
+    const supply = await uFragments.totalSupply()
+    await expect(uFragments.connect(policy).rebase(supply))
       .to.emit(uFragments, 'LogRebase')
-      .withArgs(1, initialSupply)
+      .withArgs(initialSupply)
   })
 
   it('should NOT CHANGE the totalSupply', async function () {
@@ -373,9 +381,10 @@ describe('UFragments:Rebase:Contraction', function () {
   })
 
   it('should emit Rebase', async function () {
-    await expect(uFragments.connect(policy).rebase(1, -rebaseAmt))
+    const supply = await uFragments.totalSupply()
+    await expect(uFragments.connect(policy).rebase(supply.sub(rebaseAmt)))
       .to.emit(uFragments, 'LogRebase')
-      .withArgs(1, initialSupply.sub(rebaseAmt))
+      .withArgs(initialSupply.sub(rebaseAmt))
   })
 
   it('should decrease the totalSupply', async function () {

--- a/test/unit/UFragmentsPolicy.ts
+++ b/test/unit/UFragmentsPolicy.ts
@@ -3,23 +3,16 @@ import { Contract, Signer, BigNumber, BigNumberish, Event } from 'ethers'
 import { TransactionResponse } from '@ethersproject/providers'
 import { expect } from 'chai'
 import { Result } from 'ethers/lib/utils'
-import { imul, increaseTime } from '../utils/utils'
+import { imul } from '../utils/utils'
 
 let uFragmentsPolicy: Contract,
   mockUFragments: Contract,
-  mockMarketOracle: Contract,
-  mockCpiOracle: Contract
-let prevEpoch: BigNumber, prevTime: BigNumber
-let deployer: Signer, user: Signer, orchestrator: Signer
+  mockCollateralToken: Contract,
+  mockMarketOracle: Contract
+let deployer: Signer, user: Signer
 
-const MAX_RATE = ethers.utils.parseUnits('1', 24)
-const MAX_SUPPLY = ethers.BigNumber.from(2).pow(255).sub(1).div(MAX_RATE)
-const BASE_CPI = ethers.utils.parseUnits('1', 20)
-const INITIAL_CPI = ethers.utils.parseUnits('251.712', 18)
-
-const INITIAL_CPI_25P_MORE = imul(INITIAL_CPI, '1.25', 1)
-const INITIAL_CPI_25P_LESS = imul(INITIAL_CPI, '0.77', 1)
-const INITIAL_RATE = imul(INITIAL_CPI, 1e18, BASE_CPI)
+const INITIAL_COLLATERAL_BALANCE = ethers.utils.parseUnits('1', 18)
+const INITIAL_RATE = ethers.utils.parseUnits('1', 8)
 const INITIAL_RATE_30P_MORE = imul(INITIAL_RATE, '1.3', 1)
 const INITIAL_RATE_30P_LESS = imul(INITIAL_RATE, '0.7', 1)
 const INITIAL_RATE_5P_MORE = imul(INITIAL_RATE, '1.05', 1)
@@ -29,80 +22,58 @@ const INITIAL_RATE_2X = INITIAL_RATE.mul(2)
 
 async function mockedUpgradablePolicy() {
   // get signers
-  const [deployer, user, orchestrator] = await ethers.getSigners()
+  const [deployer, user] = await ethers.getSigners()
   // deploy mocks
   const mockUFragments = await (
     await ethers.getContractFactory('MockUFragments')
   )
     .connect(deployer)
     .deploy()
+
+  const mockCollateralToken = await (
+    await ethers.getContractFactory('MockERC20Token')
+  )
+    .connect(deployer)
+    .deploy()
   const mockMarketOracle = await (await ethers.getContractFactory('MockOracle'))
     .connect(deployer)
     .deploy('MarketOracle')
-  const mockCpiOracle = await (await ethers.getContractFactory('MockOracle'))
-    .connect(deployer)
-    .deploy('CpiOracle')
   // deploy upgradable contract
   const uFragmentsPolicy = await upgrades.deployProxy(
     (await ethers.getContractFactory('UFragmentsPolicy')).connect(deployer),
-    [await deployer.getAddress(), mockUFragments.address, BASE_CPI.toString()],
+    [
+      await deployer.getAddress(),
+      mockUFragments.address,
+      mockCollateralToken.address,
+    ],
     {
-      initializer: 'initialize(address,address,uint256)',
+      initializer: 'initialize(address,address,address)',
     },
   )
   // setup oracles
   await uFragmentsPolicy
     .connect(deployer)
     .setMarketOracle(mockMarketOracle.address)
-  await uFragmentsPolicy.connect(deployer).setCpiOracle(mockCpiOracle.address)
-  await uFragmentsPolicy
-    .connect(deployer)
-    .setOrchestrator(await orchestrator.getAddress())
   // return entities
   return {
     deployer,
     user,
-    orchestrator,
     mockUFragments,
     mockMarketOracle,
-    mockCpiOracle,
-    uFragmentsPolicy,
-  }
-}
-
-async function mockedUpgradablePolicyWithOpenRebaseWindow() {
-  const {
-    deployer,
-    user,
-    orchestrator,
-    mockUFragments,
-    mockMarketOracle,
-    mockCpiOracle,
-    uFragmentsPolicy,
-  } = await mockedUpgradablePolicy()
-  await uFragmentsPolicy.connect(deployer).setRebaseTimingParameters(60, 0, 60)
-  return {
-    deployer,
-    user,
-    orchestrator,
-    mockUFragments,
-    mockMarketOracle,
-    mockCpiOracle,
+    mockCollateralToken,
     uFragmentsPolicy,
   }
 }
 
 async function mockExternalData(
   rate: BigNumberish,
-  cpi: BigNumberish,
+  collateralBalance: BigNumberish,
   uFragSupply: BigNumberish,
   rateValidity = true,
-  cpiValidity = true,
 ) {
   await mockMarketOracle.connect(deployer).storeData(rate)
   await mockMarketOracle.connect(deployer).storeValidity(rateValidity)
-  await mockCpiOracle.connect(deployer).storeData(cpi)
-  await mockCpiOracle.connect(deployer).storeValidity(cpiValidity)
+  await mockCollateralToken.connect(deployer).storeBalance(collateralBalance)
   await mockUFragments.connect(deployer).storeSupply(uFragSupply)
 }
 
@@ -119,10 +90,9 @@ describe('UFragmentsPolicy', function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
     } = await waffle.loadFixture(mockedUpgradablePolicy))
   })
@@ -140,46 +110,25 @@ describe('UFragmentsPolicy:initialize', async function () {
       ;({
         deployer,
         user,
-        orchestrator,
+        mockCollateralToken,
         mockUFragments,
         mockMarketOracle,
-        mockCpiOracle,
         uFragmentsPolicy,
       } = await waffle.loadFixture(mockedUpgradablePolicy))
     })
 
-    it('deviationThreshold', async function () {
-      expect(await uFragmentsPolicy.deviationThreshold()).to.eq(
-        ethers.utils.parseUnits('5', 16),
-      )
-    })
-    it('rebaseLag', async function () {
-      expect(await uFragmentsPolicy.rebaseLag()).to.eq(30)
-    })
-    it('minRebaseTimeIntervalSec', async function () {
-      expect(await uFragmentsPolicy.minRebaseTimeIntervalSec()).to.eq(
-        24 * 60 * 60,
-      )
-    })
-    it('epoch', async function () {
-      expect(await uFragmentsPolicy.epoch()).to.eq(0)
-    })
-    it('globalAmpleforthEpochAndAMPLSupply', async function () {
-      const r = await uFragmentsPolicy.globalAmpleforthEpochAndAMPLSupply()
-      expect(r[0]).to.eq(0)
-      expect(r[1]).to.eq(0)
-    })
-    it('rebaseWindowOffsetSec', async function () {
-      expect(await uFragmentsPolicy.rebaseWindowOffsetSec()).to.eq(72000)
-    })
-    it('rebaseWindowLengthSec', async function () {
-      expect(await uFragmentsPolicy.rebaseWindowLengthSec()).to.eq(900)
-    })
     it('should set owner', async function () {
       expect(await uFragmentsPolicy.owner()).to.eq(await deployer.getAddress())
     })
+
     it('should set reference to uFragments', async function () {
       expect(await uFragmentsPolicy.uFrags()).to.eq(mockUFragments.address)
+    })
+
+    it('should set reference to collateralToken', async function () {
+      expect(await uFragmentsPolicy.collateralToken()).to.eq(
+        mockCollateralToken.address,
+      )
     })
   })
 })
@@ -189,10 +138,9 @@ describe('UFragmentsPolicy:setMarketOracle', async function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
     } = await waffle.loadFixture(mockedUpgradablePolicy))
   })
@@ -212,10 +160,9 @@ describe('UFragments:setMarketOracle:accessControl', function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
     } = await waffle.loadFixture(mockedUpgradablePolicy))
   })
@@ -233,279 +180,6 @@ describe('UFragments:setMarketOracle:accessControl', function () {
       uFragmentsPolicy
         .connect(user)
         .setMarketOracle(await deployer.getAddress()),
-    ).to.be.reverted
-  })
-})
-
-describe('UFragmentsPolicy:setCpiOracle', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should set cpiOracle', async function () {
-    await uFragmentsPolicy
-      .connect(deployer)
-      .setCpiOracle(await deployer.getAddress())
-    expect(await uFragmentsPolicy.cpiOracle()).to.eq(
-      await deployer.getAddress(),
-    )
-  })
-})
-
-describe('UFragments:setCpiOracle:accessControl', function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should be callable by owner', async function () {
-    await expect(
-      uFragmentsPolicy
-        .connect(deployer)
-        .setCpiOracle(await deployer.getAddress()),
-    ).to.not.be.reverted
-  })
-
-  it('should NOT be callable by non-owner', async function () {
-    await expect(
-      uFragmentsPolicy.connect(user).setCpiOracle(await deployer.getAddress()),
-    ).to.be.reverted
-  })
-})
-
-describe('UFragmentsPolicy:setOrchestrator', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should set orchestrator', async function () {
-    await uFragmentsPolicy
-      .connect(deployer)
-      .setOrchestrator(await user.getAddress())
-    expect(await uFragmentsPolicy.orchestrator()).to.eq(await user.getAddress())
-  })
-})
-
-describe('UFragments:setOrchestrator:accessControl', function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should be callable by owner', async function () {
-    await expect(
-      uFragmentsPolicy
-        .connect(deployer)
-        .setOrchestrator(await deployer.getAddress()),
-    ).to.not.be.reverted
-  })
-
-  it('should NOT be callable by non-owner', async function () {
-    await expect(
-      uFragmentsPolicy
-        .connect(user)
-        .setOrchestrator(await deployer.getAddress()),
-    ).to.be.reverted
-  })
-})
-
-describe('UFragmentsPolicy:setDeviationThreshold', async function () {
-  let prevThreshold: BigNumber, threshold: BigNumber
-  before('setup UFragmentsPolicy contract', async function () {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-    prevThreshold = await uFragmentsPolicy.deviationThreshold()
-    threshold = prevThreshold.add(ethers.utils.parseUnits('1', 16))
-    await uFragmentsPolicy.connect(deployer).setDeviationThreshold(threshold)
-  })
-
-  it('should set deviationThreshold', async function () {
-    expect(await uFragmentsPolicy.deviationThreshold()).to.eq(threshold)
-  })
-})
-
-describe('UFragments:setDeviationThreshold:accessControl', function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should be callable by owner', async function () {
-    await expect(uFragmentsPolicy.connect(deployer).setDeviationThreshold(0)).to
-      .not.be.reverted
-  })
-
-  it('should NOT be callable by non-owner', async function () {
-    await expect(uFragmentsPolicy.connect(user).setDeviationThreshold(0)).to.be
-      .reverted
-  })
-})
-
-describe('UFragmentsPolicy:setRebaseLag', async function () {
-  let prevLag: BigNumber
-  before('setup UFragmentsPolicy contract', async function () {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-    prevLag = await uFragmentsPolicy.rebaseLag()
-  })
-
-  describe('when rebaseLag is more than 0', async function () {
-    it('should setRebaseLag', async function () {
-      const lag = prevLag.add(1)
-      await uFragmentsPolicy.connect(deployer).setRebaseLag(lag)
-      expect(await uFragmentsPolicy.rebaseLag()).to.eq(lag)
-    })
-  })
-
-  describe('when rebaseLag is 0', async function () {
-    it('should fail', async function () {
-      await expect(uFragmentsPolicy.connect(deployer).setRebaseLag(0)).to.be
-        .reverted
-    })
-  })
-})
-
-describe('UFragments:setRebaseLag:accessControl', function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should be callable by owner', async function () {
-    await expect(uFragmentsPolicy.connect(deployer).setRebaseLag(1)).to.not.be
-      .reverted
-  })
-
-  it('should NOT be callable by non-owner', async function () {
-    await expect(uFragmentsPolicy.connect(user).setRebaseLag(1)).to.be.reverted
-  })
-})
-
-describe('UFragmentsPolicy:setRebaseTimingParameters', async function () {
-  before('setup UFragmentsPolicy contract', async function () {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  describe('when interval=0', function () {
-    it('should fail', async function () {
-      await expect(
-        uFragmentsPolicy.connect(deployer).setRebaseTimingParameters(0, 0, 0),
-      ).to.be.reverted
-    })
-  })
-
-  describe('when offset > interval', function () {
-    it('should fail', async function () {
-      await expect(
-        uFragmentsPolicy
-          .connect(deployer)
-          .setRebaseTimingParameters(300, 3600, 300),
-      ).to.be.reverted
-    })
-  })
-
-  describe('when params are valid', function () {
-    it('should setRebaseTimingParameters', async function () {
-      await uFragmentsPolicy
-        .connect(deployer)
-        .setRebaseTimingParameters(600, 60, 300)
-      expect(await uFragmentsPolicy.minRebaseTimeIntervalSec()).to.eq(600)
-      expect(await uFragmentsPolicy.rebaseWindowOffsetSec()).to.eq(60)
-      expect(await uFragmentsPolicy.rebaseWindowLengthSec()).to.eq(300)
-    })
-  })
-})
-
-describe('UFragments:setRebaseTimingParameters:accessControl', function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicy))
-  })
-
-  it('should be callable by owner', async function () {
-    await expect(
-      uFragmentsPolicy
-        .connect(deployer)
-        .setRebaseTimingParameters(600, 60, 300),
-    ).to.not.be.reverted
-  })
-
-  it('should NOT be callable by non-owner', async function () {
-    await expect(
-      uFragmentsPolicy.connect(user).setRebaseTimingParameters(600, 60, 300),
     ).to.be.reverted
   })
 })
@@ -515,27 +189,22 @@ describe('UFragmentsPolicy:Rebase:accessControl', async function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-    // await setupContractsWithOpenRebaseWindow()
-    await mockExternalData(INITIAL_RATE_30P_MORE, INITIAL_CPI, 1000, true)
-    await increaseTime(60)
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
+    await mockExternalData(
+      INITIAL_RATE_30P_MORE,
+      INITIAL_COLLATERAL_BALANCE,
+      1000,
+      true,
+    )
   })
 
-  describe('when rebase called by orchestrator', function () {
+  describe('when rebase called by anybody', function () {
     it('should succeed', async function () {
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.not.be
-        .reverted
-    })
-  })
-
-  describe('when rebase called by non-orchestrator', function () {
-    it('should fail', async function () {
-      await expect(uFragmentsPolicy.connect(user).rebase()).to.be.reverted
+      await expect(uFragmentsPolicy.connect(user).rebase()).not.to.be.reverted
     })
   })
 })
@@ -545,535 +214,259 @@ describe('UFragmentsPolicy:Rebase', async function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when minRebaseTimeIntervalSec has NOT passed since the previous rebase', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE_30P_MORE, INITIAL_CPI, 1010)
-      await increaseTime(60)
-      await uFragmentsPolicy.connect(orchestrator).rebase()
-    })
-
-    it('should fail', async function () {
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.be
-        .reverted
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when rate is within deviationThreshold', function () {
-    before(async function () {
-      await uFragmentsPolicy
-        .connect(deployer)
-        .setRebaseTimingParameters(60, 0, 60)
-    })
-
-    it('should return 0', async function () {
-      await mockExternalData(INITIAL_RATE.sub(1), INITIAL_CPI, 1000)
-      await increaseTime(60)
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-      await increaseTime(60)
-
-      await mockExternalData(INITIAL_RATE.add(1), INITIAL_CPI, 1000)
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-      await increaseTime(60)
-
-      await mockExternalData(INITIAL_RATE_5P_MORE.sub(2), INITIAL_CPI, 1000)
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-      await increaseTime(60)
-
-      await mockExternalData(INITIAL_RATE_5P_LESS.add(2), INITIAL_CPI, 1000)
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-      await increaseTime(60)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when rate is more than MAX_RATE', function () {
-    it('should return same supply delta as delta for MAX_RATE', async function () {
-      // Any exchangeRate >= (MAX_RATE=100x) would result in the same supply increase
-      await mockExternalData(MAX_RATE, INITIAL_CPI, 1000)
-      await increaseTime(60)
-
-      const supplyChange = (
-        await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase())
-      ).requestedSupplyAdjustment
-
-      await increaseTime(60)
-
-      await mockExternalData(
-        MAX_RATE.add(ethers.utils.parseUnits('1', 17)),
-        INITIAL_CPI,
-        1000,
-      )
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(supplyChange)
-
-      await increaseTime(60)
-
-      await mockExternalData(MAX_RATE.mul(2), INITIAL_CPI, 1000)
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(supplyChange)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when uFragments grows beyond MAX_SUPPLY', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE_2X, INITIAL_CPI, MAX_SUPPLY.sub(1))
-      await increaseTime(60)
-    })
-
-    it('should apply SupplyAdjustment {MAX_SUPPLY - totalSupply}', async function () {
-      // Supply is MAX_SUPPLY-1, exchangeRate is 2x; resulting in a new supply more than MAX_SUPPLY
-      // However, supply is ONLY increased by 1 to MAX_SUPPLY
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(1)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when uFragments supply equals MAX_SUPPLY and rebase attempts to grow', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE_2X, INITIAL_CPI, MAX_SUPPLY)
-      await increaseTime(60)
-    })
-
-    it('should not grow', async function () {
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
   })
 
   describe('when the market oracle returns invalid data', function () {
     it('should fail', async function () {
-      await mockExternalData(INITIAL_RATE_30P_MORE, INITIAL_CPI, 1000, false)
-      await increaseTime(60)
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.be
-        .reverted
+      await mockExternalData(
+        INITIAL_RATE_30P_MORE,
+        INITIAL_COLLATERAL_BALANCE,
+        1000,
+        false,
+      )
+      await expect(uFragmentsPolicy.connect(user).rebase()).to.be.reverted
     })
   })
 
   describe('when the market oracle returns valid data', function () {
     it('should NOT fail', async function () {
-      await mockExternalData(INITIAL_RATE_30P_MORE, INITIAL_CPI, 1000, true)
-      await increaseTime(60)
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.not.be
-        .reverted
+      await mockExternalData(
+        INITIAL_RATE_30P_MORE,
+        INITIAL_COLLATERAL_BALANCE,
+        1000,
+        true,
+      )
+      await expect(uFragmentsPolicy.connect(user).rebase()).to.not.be.reverted
     })
   })
 })
 
 describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
+  beforeEach('setup UFragmentsPolicy contract', async function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
+    await mockExternalData(
+      INITIAL_RATE_30P_MORE,
+      INITIAL_COLLATERAL_BALANCE,
+      1000,
+      true,
+    )
   })
 
-  describe('when the cpi oracle returns invalid data', function () {
-    it('should fail', async function () {
-      await mockExternalData(
-        INITIAL_RATE_30P_MORE,
-        INITIAL_CPI,
-        1000,
-        true,
-        false,
-      )
-      await increaseTime(60)
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.be
-        .reverted
-    })
-  })
-
-  describe('when the cpi oracle returns valid data', function () {
-    it('should NOT fail', async function () {
-      await mockExternalData(
-        INITIAL_RATE_30P_MORE,
-        INITIAL_CPI,
-        1000,
-        true,
-        true,
-      )
-      await increaseTime(60)
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.not.be
-        .reverted
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('positive rate and no change CPI', function () {
-    beforeEach(async function () {
-      await mockExternalData(INITIAL_RATE_30P_MORE, INITIAL_CPI, 1000)
-      await uFragmentsPolicy
-        .connect(deployer)
-        .setRebaseTimingParameters(60, 0, 60)
-      await increaseTime(60)
-      await uFragmentsPolicy.connect(orchestrator).rebase()
-      prevEpoch = await uFragmentsPolicy.epoch()
-      prevTime = await uFragmentsPolicy.lastRebaseTimestampSec()
-      await mockExternalData(INITIAL_RATE_60P_MORE, INITIAL_CPI, 1010)
-      await increaseTime(60)
-    })
-
-    it('should increment epoch', async function () {
-      await uFragmentsPolicy.connect(orchestrator).rebase()
-      expect(await uFragmentsPolicy.epoch()).to.eq(prevEpoch.add(1))
-    })
-
-    it('should update globalAmpleforthEpochAndAMPLSupply', async function () {
-      await uFragmentsPolicy.connect(orchestrator).rebase()
-      const r = await uFragmentsPolicy.globalAmpleforthEpochAndAMPLSupply()
-      expect(r[0]).to.eq(prevEpoch.add(1))
-      expect(r[1]).to.eq('1010')
-    })
-
-    it('should update lastRebaseTimestamp', async function () {
-      await uFragmentsPolicy.connect(orchestrator).rebase()
-      const time = await uFragmentsPolicy.lastRebaseTimestampSec()
-      expect(time.sub(prevTime)).to.gte(60)
-    })
-
-    it('should emit Rebase with positive requestedSupplyAdjustment', async function () {
-      const r = uFragmentsPolicy.connect(orchestrator).rebase()
+  describe('rate increases', function () {
+    it('should increase supply', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
       await expect(r)
         .to.emit(uFragmentsPolicy, 'LogRebase')
         .withArgs(
-          prevEpoch.add(1),
-          INITIAL_RATE_60P_MORE,
-          INITIAL_CPI,
-          20,
-          (await parseRebaseLog(r)).timestampSec,
+          INITIAL_RATE_30P_MORE,
+          imul(INITIAL_COLLATERAL_BALANCE, 1.3, 1),
         )
     })
 
     it('should call getData from the market oracle', async function () {
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase())
+      await expect(uFragmentsPolicy.connect(user).rebase())
         .to.emit(mockMarketOracle, 'FunctionCalled')
         .withArgs('MarketOracle', 'getData', uFragmentsPolicy.address)
     })
 
-    it('should call getData from the cpi oracle', async function () {
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase())
-        .to.emit(mockCpiOracle, 'FunctionCalled')
-        .withArgs('CpiOracle', 'getData', uFragmentsPolicy.address)
-    })
-
     it('should call uFrag Rebase', async function () {
-      const r = uFragmentsPolicy.connect(orchestrator).rebase()
+      const r = uFragmentsPolicy.connect(user).rebase()
       await expect(r)
         .to.emit(mockUFragments, 'FunctionCalled')
         .withArgs('UFragments', 'rebase', uFragmentsPolicy.address)
       await expect(r)
         .to.emit(mockUFragments, 'FunctionArguments')
-        .withArgs([prevEpoch.add(1)], [20])
+        .withArgs([imul(INITIAL_COLLATERAL_BALANCE, 1.3, 1)], [])
     })
   })
 })
 
 describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('negative rate', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE_30P_LESS, INITIAL_CPI, 1000)
-      await increaseTime(60)
-    })
-
-    it('should emit Rebase with negative requestedSupplyAdjustment', async function () {
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(-10)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when cpi increases', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE, INITIAL_CPI_25P_MORE, 1000)
-      await increaseTime(60)
-      await uFragmentsPolicy.connect(deployer).setDeviationThreshold(0)
-    })
-
-    it('should emit Rebase with negative requestedSupplyAdjustment', async function () {
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(-6)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('when cpi decreases', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE, INITIAL_CPI_25P_LESS, 1000)
-      await increaseTime(60)
-      await uFragmentsPolicy.connect(deployer).setDeviationThreshold(0)
-    })
-
-    it('should emit Rebase with positive requestedSupplyAdjustment', async function () {
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(9)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  before('setup UFragmentsPolicy contract', async () => {
-    ;({
-      deployer,
-      user,
-      orchestrator,
-      mockUFragments,
-      mockMarketOracle,
-      mockCpiOracle,
-      uFragmentsPolicy,
-    } = await waffle.loadFixture(mockedUpgradablePolicyWithOpenRebaseWindow))
-  })
-
-  describe('rate=TARGET_RATE', function () {
-    before(async function () {
-      await mockExternalData(INITIAL_RATE, INITIAL_CPI, 1000)
-      await uFragmentsPolicy.connect(deployer).setDeviationThreshold(0)
-      await increaseTime(60)
-    })
-
-    it('should emit Rebase with 0 requestedSupplyAdjustment', async function () {
-      expect(
-        (await parseRebaseLog(uFragmentsPolicy.connect(orchestrator).rebase()))
-          .requestedSupplyAdjustment,
-      ).to.eq(0)
-    })
-  })
-})
-
-describe('UFragmentsPolicy:Rebase', async function () {
-  let rbTime: BigNumber,
-    rbWindow: BigNumber,
-    minRebaseTimeIntervalSec: BigNumber,
-    now: BigNumber,
-    nextRebaseWindowOpenTime: BigNumber,
-    timeToWait: BigNumber,
-    lastRebaseTimestamp: BigNumber
-
   beforeEach('setup UFragmentsPolicy contract', async function () {
     ;({
       deployer,
       user,
-      orchestrator,
+      mockCollateralToken,
       mockUFragments,
       mockMarketOracle,
-      mockCpiOracle,
       uFragmentsPolicy,
     } = await waffle.loadFixture(mockedUpgradablePolicy))
-    await uFragmentsPolicy
-      .connect(deployer)
-      .setRebaseTimingParameters(86400, 72000, 900)
-    await mockExternalData(INITIAL_RATE, INITIAL_CPI, 1000)
-    rbTime = await uFragmentsPolicy.rebaseWindowOffsetSec()
-    rbWindow = await uFragmentsPolicy.rebaseWindowLengthSec()
-    minRebaseTimeIntervalSec = await uFragmentsPolicy.minRebaseTimeIntervalSec()
-    now = ethers.BigNumber.from(
-      (await ethers.provider.getBlock('latest')).timestamp,
+    await mockExternalData(
+      INITIAL_RATE_30P_LESS,
+      INITIAL_COLLATERAL_BALANCE,
+      1000,
+      true,
     )
-    nextRebaseWindowOpenTime = now
-      .sub(now.mod(minRebaseTimeIntervalSec))
-      .add(rbTime)
-      .add(minRebaseTimeIntervalSec)
   })
 
-  describe('when its 5s after the rebase window closes', function () {
-    it('should fail', async function () {
-      timeToWait = nextRebaseWindowOpenTime.sub(now).add(rbWindow).add(5)
-      await increaseTime(timeToWait)
-      expect(await uFragmentsPolicy.inRebaseWindow()).to.be.false
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.be
-        .reverted
+  describe('rate decreases', function () {
+    it('should decrease supply', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(uFragmentsPolicy, 'LogRebase')
+        .withArgs(
+          INITIAL_RATE_30P_LESS,
+          imul(INITIAL_COLLATERAL_BALANCE, 0.7, 1),
+        )
+    })
+
+    it('should call getData from the market oracle', async function () {
+      await expect(uFragmentsPolicy.connect(user).rebase())
+        .to.emit(mockMarketOracle, 'FunctionCalled')
+        .withArgs('MarketOracle', 'getData', uFragmentsPolicy.address)
+    })
+
+    it('should call uFrag Rebase', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionCalled')
+        .withArgs('UFragments', 'rebase', uFragmentsPolicy.address)
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionArguments')
+        .withArgs([imul(INITIAL_COLLATERAL_BALANCE, 0.7, 1)], [])
     })
   })
+})
 
-  describe('when its 5s before the rebase window opens', function () {
-    it('should fail', async function () {
-      timeToWait = nextRebaseWindowOpenTime.sub(now).sub(5)
-      await increaseTime(timeToWait)
-      expect(await uFragmentsPolicy.inRebaseWindow()).to.be.false
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.be
-        .reverted
-    })
+describe('UFragmentsPolicy:Rebase', async function () {
+  beforeEach('setup UFragmentsPolicy contract', async function () {
+    ;({
+      deployer,
+      user,
+      mockCollateralToken,
+      mockUFragments,
+      mockMarketOracle,
+      uFragmentsPolicy,
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
+    await mockExternalData(
+      INITIAL_RATE,
+      INITIAL_COLLATERAL_BALANCE.mul(2),
+      1000,
+      true,
+    )
   })
 
-  describe('when its 5s after the rebase window opens', function () {
-    it('should NOT fail', async function () {
-      timeToWait = nextRebaseWindowOpenTime.sub(now).add(5)
-      await increaseTime(timeToWait)
-      expect(await uFragmentsPolicy.inRebaseWindow()).to.be.true
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.not.be
-        .reverted
-      lastRebaseTimestamp = await uFragmentsPolicy.lastRebaseTimestampSec()
-      expect(lastRebaseTimestamp).to.eq(nextRebaseWindowOpenTime)
+  describe('collateral balance increases', function () {
+    it('should increase supply', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(uFragmentsPolicy, 'LogRebase')
+        .withArgs(INITIAL_RATE, INITIAL_COLLATERAL_BALANCE.mul(2))
+    })
+
+    it('should call getData from the market oracle', async function () {
+      await expect(uFragmentsPolicy.connect(user).rebase())
+        .to.emit(mockMarketOracle, 'FunctionCalled')
+        .withArgs('MarketOracle', 'getData', uFragmentsPolicy.address)
+    })
+
+    it('should call uFrag Rebase', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionCalled')
+        .withArgs('UFragments', 'rebase', uFragmentsPolicy.address)
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionArguments')
+        .withArgs([imul(INITIAL_COLLATERAL_BALANCE, 2, 1)], [])
     })
   })
+})
 
-  describe('when its 5s before the rebase window closes', function () {
-    it('should NOT fail', async function () {
-      timeToWait = nextRebaseWindowOpenTime.sub(now).add(rbWindow).sub(5)
-      await increaseTime(timeToWait)
-      expect(await uFragmentsPolicy.inRebaseWindow()).to.be.true
-      await expect(uFragmentsPolicy.connect(orchestrator).rebase()).to.not.be
-        .reverted
-      lastRebaseTimestamp = await uFragmentsPolicy.lastRebaseTimestampSec.call()
-      expect(lastRebaseTimestamp).to.eq(nextRebaseWindowOpenTime)
+describe('UFragmentsPolicy:Rebase', async function () {
+  beforeEach('setup UFragmentsPolicy contract', async function () {
+    ;({
+      deployer,
+      user,
+      mockCollateralToken,
+      mockUFragments,
+      mockMarketOracle,
+      uFragmentsPolicy,
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
+    await mockExternalData(
+      INITIAL_RATE,
+      imul(INITIAL_COLLATERAL_BALANCE, 0.5, 1),
+      1000,
+      true,
+    )
+  })
+
+  describe('collateral balance decreases', function () {
+    it('should decrease supply', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(uFragmentsPolicy, 'LogRebase')
+        .withArgs(INITIAL_RATE, imul(INITIAL_COLLATERAL_BALANCE, 0.5, 1))
+    })
+
+    it('should call getData from the market oracle', async function () {
+      await expect(uFragmentsPolicy.connect(user).rebase())
+        .to.emit(mockMarketOracle, 'FunctionCalled')
+        .withArgs('MarketOracle', 'getData', uFragmentsPolicy.address)
+    })
+
+    it('should call uFrag Rebase', async function () {
+      const r = uFragmentsPolicy.connect(user).rebase()
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionCalled')
+        .withArgs('UFragments', 'rebase', uFragmentsPolicy.address)
+      await expect(r)
+        .to.emit(mockUFragments, 'FunctionArguments')
+        .withArgs([imul(INITIAL_COLLATERAL_BALANCE, 0.5, 1)], [])
+    })
+  })
+})
+
+describe('UFragmentsPolicy:Rebase', async function () {
+  beforeEach('setup UFragmentsPolicy contract', async function () {
+    ;({
+      deployer,
+      user,
+      mockCollateralToken,
+      mockUFragments,
+      mockMarketOracle,
+      uFragmentsPolicy,
+    } = await waffle.loadFixture(mockedUpgradablePolicy))
+  })
+
+  describe('both rate and collateral balance change', function () {
+    it('should rebase properly', async function () {
+      // test 100 random combinations of rate and balance
+      for (let i = 0; i < 100; i++) {
+        const max = 10000
+        const min = 0.0001
+        const rate = imul(INITIAL_RATE, Math.random() * (max - min) + min, 1)
+        const balance = imul(
+          INITIAL_COLLATERAL_BALANCE,
+          Math.random() * (max - min) + min,
+          1,
+        )
+        const expectedSupply = rate.mul(balance).div(10 ** 8)
+        await mockExternalData(rate, balance, 1000, true)
+
+        const r = uFragmentsPolicy.connect(user).rebase()
+        await expect(r)
+          .to.emit(uFragmentsPolicy, 'LogRebase')
+          .withArgs(rate, expectedSupply)
+
+        await expect(r)
+          .to.emit(mockUFragments, 'FunctionCalled')
+          .withArgs('UFragments', 'rebase', uFragmentsPolicy.address)
+        await expect(r)
+          .to.emit(mockUFragments, 'FunctionArguments')
+          .withArgs([expectedSupply], [])
+      }
     })
   })
 })


### PR DESCRIPTION
This commit updates the rebase functionality to snap to the total value
of the underlying collateral, with unit value of $1. To do this, we
remove some unnecessary features from uFragments - CPI, rebase
dampening, time windows, and deviation thresholds. We add a reference to
the underlying collateral token and, upon rebase, change
_gonsPerFragment such that the total supply is equivalent to the total
value of the underlying collateral tokens.