### PR TITLE
Dropping price cache time parameter

### DIFF
--- a/test/simulation/precision.ts
+++ b/test/simulation/precision.ts
@@ -152,7 +152,6 @@ async function exec() {
   buttonToken = await buttonTokenFactory
     .connect(deployer)
     .deploy(mockBTC.address, 'TEST', 'TEST', mockOracle.address)
-  await buttonToken.connect(deployer).setMinUpdateIntervalSec(0)
 
   await mockBTC
     .connect(deployer)

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -8,9 +8,18 @@ export const imul = (a: BigNumberish, b: BigNumberish, c: BigNumberish) => {
   )
 }
 
+export const timeNow = async () => {
+  return (await ethers.provider.getBlock('latest')).timestamp
+}
+
 export const increaseTime = async (seconds: BigNumberish) => {
-  const now = (await ethers.provider.getBlock('latest')).timestamp
   await ethers.provider.send('evm_mine', [
-    ethers.BigNumber.from(seconds).add(now).toNumber(),
+    ethers.BigNumber.from(seconds)
+      .add(await timeNow())
+      .toNumber(),
   ])
+}
+
+export const setTime = async (time: BigNumberish) => {
+  await ethers.provider.send('evm_setNextBlockTimestamp', [time])
 }


### PR DESCRIPTION
I think we should move this to the oracle contract layer and keep the surface area of the button token governance clean. The owner can just "swap" oracles. 

I think the question of "how long is the data from the oracle valid?" is an oracle question and should be informed by the chosen oracle. If we want to add delay or cache logic, we should do it on the oracle contract.

