### PR TITLE
fix(coc): update chainlink oracle for audit

### DIFF
--- a/contracts/interfaces/IChainlinkAggregator.sol
+++ b/contracts/interfaces/IChainlinkAggregator.sol
@@ -1,5 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
 
 interface IChainlinkAggregator {
-    function latestAnswer() external view returns (uint256);
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 }

--- a/contracts/mocks/MockChainlinkAggregator.sol
+++ b/contracts/mocks/MockChainlinkAggregator.sol
@@ -10,12 +10,24 @@ import "../interfaces/IChainlinkAggregator.sol";
  */
 contract MockChainlinkAggregator is IChainlinkAggregator {
     uint256 public answer;
+    uint256 public updatedAt;
 
     /**
      * Get the latest answer from the oracle
      */
-    function latestAnswer() external view override returns (uint256) {
-        return answer;
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 _answer,
+            uint256 startedAt,
+            uint256 _updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (0, int256(answer), 0, updatedAt, 0);
     }
 
     /**
@@ -23,5 +35,12 @@ contract MockChainlinkAggregator is IChainlinkAggregator {
      */
     function setLatestAnswer(uint256 _answer) public {
         answer = _answer;
+    }
+
+    /**
+     * Set the latest answer to be returned from now on
+     */
+    function setUpdatedAt(uint256 _updatedAt) public {
+        updatedAt = _updatedAt;
     }
 }


### PR DESCRIPTION
This commit fixes COC-1 and COC-2 from the CertiK audit - updating the
interface and adding immutable tag to variable