### PR TITLE
fix: zero oracle price

### DIFF
--- a/tasks/deployers/button.ts
+++ b/tasks/deployers/button.ts
@@ -2,12 +2,11 @@ import { Signer } from '@ethersproject/abstract-signer'
 import { task, types } from 'hardhat/config'
 import { TaskArguments } from 'hardhat/types'
 
-task('deploy:ButtonTokenFactory')
-  .setAction(async function (
+task('deploy:ButtonTokenFactory').setAction(async function (
   _args: TaskArguments,
   hre,
 ) {
-  console.log('Signer', await (await hre.ethers.getSigners())[0].getAddress());
+  console.log('Signer', await (await hre.ethers.getSigners())[0].getAddress())
   const TokenTemplate = await hre.ethers.getContractFactory('ButtonToken')
   const tokenTemplate = await TokenTemplate.deploy()
   await tokenTemplate.deployed()
@@ -75,8 +74,15 @@ task('deploy:ButtonToken')
       factory,
     )
 
-    const deployedAddress = await bFactory.callStatic['create(address,string,string,address)'](underlying, name, symbol, oracle)
-    const tx = await bFactory['create(address,string,string,address)'](underlying, name, symbol, oracle)
+    const deployedAddress = await bFactory.callStatic[
+      'create(address,string,string,address)'
+    ](underlying, name, symbol, oracle)
+    const tx = await bFactory['create(address,string,string,address)'](
+      underlying,
+      name,
+      symbol,
+      oracle,
+    )
     await tx.wait()
     console.log('Successfully created tx', tx.hash)
     console.log('Token will be deployed to', deployedAddress)
@@ -92,10 +98,15 @@ task('deploy:ChainlinkOracle')
   .addParam('aggregator', 'the address of the backing chainlink aggregator')
   .addParam('stalenessThresholdSecs', 'the number of seconds before refresh')
   .setAction(async function (args: TaskArguments, hre) {
-      const { aggregator, stalenessThresholdSecs } = args
-      const ChainlinkOracle = await hre.ethers.getContractFactory('ChainlinkOracle')
-      const oracle = await ChainlinkOracle.deploy(aggregator, stalenessThresholdSecs)
-      await oracle.deployed()
-      console.log(`Oracle deployed to ${oracle.address}`)
-      return oracle.address;
+    const { aggregator, stalenessThresholdSecs } = args
+    const ChainlinkOracle = await hre.ethers.getContractFactory(
+      'ChainlinkOracle',
+    )
+    const oracle = await ChainlinkOracle.deploy(
+      aggregator,
+      stalenessThresholdSecs,
+    )
+    await oracle.deployed()
+    console.log(`Oracle deployed to ${oracle.address}`)
+    return oracle.address
   })


### PR DESCRIPTION
This commit takes zero price oracle responses to be invalid, and retains
the existing valid oracle price. This avoids a situation where funds are
frozen (due to inability to do accounting calculations with 0-price)