### PR TITLE
fix: button token return values dont match interface

### DIFF
--- a/contracts/ButtonToken.sol
+++ b/contracts/ButtonToken.sol
@@ -360,7 +360,7 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         uint256 bits = _amountToBits(amount, lastPrice);
         uint256 uAmount = _bitsToUAmount(bits);
         _deposit(_msgSender(), _msgSender(), uAmount, amount, bits);
-        return amount;
+        return uAmount;
     }
 
     /// @inheritdoc IButtonWrapper
@@ -368,7 +368,7 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         uint256 bits = _amountToBits(amount, lastPrice);
         uint256 uAmount = _bitsToUAmount(bits);
         _deposit(_msgSender(), to, uAmount, amount, bits);
-        return amount;
+        return uAmount;
     }
 
     /// @inheritdoc IButtonWrapper
@@ -376,7 +376,7 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         uint256 bits = _amountToBits(amount, lastPrice);
         uint256 uAmount = _bitsToUAmount(bits);
         _withdraw(_msgSender(), _msgSender(), uAmount, amount, bits);
-        return amount;
+        return uAmount;
     }
 
     /// @inheritdoc IButtonWrapper
@@ -384,7 +384,7 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         uint256 bits = _amountToBits(amount, lastPrice);
         uint256 uAmount = _bitsToUAmount(bits);
         _withdraw(_msgSender(), to, uAmount, amount, bits);
-        return amount;
+        return uAmount;
     }
 
     /// @inheritdoc IButtonWrapper

--- a/test/unit/ButtonToken.ts
+++ b/test/unit/ButtonToken.ts
@@ -149,6 +149,42 @@ describe('ButtonToken:updateOracle', async () => {
       expect(await buttonToken.lastPrice()).to.eq(toOracleValue('45000'))
     })
   })
+
+  describe('when the new price oracle is ZERO', function () {
+    it('should update price, freeze funds', async function () {
+      const MINT_AMT = toFixedPtAmt('1')
+
+      // legit user deposits tokens
+      await mockBTC.connect(deployer).mint(deployerAddress, MINT_AMT)
+      await mockBTC.connect(deployer).approve(buttonToken.address, MINT_AMT)
+      await buttonToken.connect(deployer).deposit(MINT_AMT)
+
+      // malicious owner updates price to zero
+      const oracleFactory = await ethers.getContractFactory('MockOracle')
+      mockOracle = await oracleFactory.connect(deployer).deploy()
+      await mockOracle.setData(toOracleValue('1'), true)
+
+      expect(await buttonToken.oracle()).to.not.eq(mockOracle.address)
+
+      await expect(
+        buttonToken.connect(deployer).updateOracle(mockOracle.address),
+      )
+        .to.emit(buttonToken, 'Rebase')
+        .withArgs('3', toOracleValue('1'))
+        .to.emit(buttonToken, 'OracleUpdated')
+        .withArgs(mockOracle.address)
+
+      await mockOracle.setData(toOracleValue('0'), true)
+      await expect(buttonToken.rebase()).to.not.be.reverted
+
+      expect(await buttonToken.oracle()).to.eq(mockOracle.address)
+      expect(await buttonToken.lastPrice()).to.eq(toOracleValue('1'))
+
+      // checks that you can still withdraw
+      await expect(buttonToken.connect(deployer).withdraw(MINT_AMT)).to.not.be
+        .reverted
+    })
+  })
 })
 
 describe('ButtonToken:Rebase:Expansion', async () => {
@@ -482,39 +518,5 @@ describe('ButtonToken:Transfer', function () {
           ),
       ).to.be.reverted
     })
-  })
-})
-
-describe('when the new price oracle is ZERO', function () {
-  it('should update price, freeze funds', async function () {
-    const MINT_AMT = toFixedPtAmt('1')
-
-    // legit user deposits tokens
-    await mockBTC.connect(deployer).mint(deployerAddress, MINT_AMT)
-    await mockBTC.connect(deployer).approve(buttonToken.address, MINT_AMT)
-    await buttonToken.connect(deployer).deposit(MINT_AMT)
-
-    // malicious owner updates price to zero
-    const oracleFactory = await ethers.getContractFactory('MockOracle')
-    mockOracle = await oracleFactory.connect(deployer).deploy()
-    await mockOracle.setData(toOracleValue('1'), true)
-
-    expect(await buttonToken.oracle()).to.not.eq(mockOracle.address)
-
-    await expect(buttonToken.connect(deployer).updateOracle(mockOracle.address))
-      .to.emit(buttonToken, 'Rebase')
-      .withArgs('2', toOracleValue('1'))
-      .to.emit(buttonToken, 'OracleUpdated')
-      .withArgs(mockOracle.address)
-
-    await mockOracle.setData(toOracleValue('0'), true)
-    await expect(buttonToken.rebase()).to.not.be.reverted
-
-    expect(await buttonToken.oracle()).to.eq(mockOracle.address)
-    expect(await buttonToken.lastPrice()).to.eq(toOracleValue('1'))
-
-    // checks that you can still withdraw
-    await expect(buttonToken.connect(deployer).withdraw(MINT_AMT)).to.not.be
-      .reverted
   })
 })

--- a/test/unit/ButtonTokenWethRouter.ts
+++ b/test/unit/ButtonTokenWethRouter.ts
@@ -71,23 +71,23 @@ describe('ButtonTokenWethRouter', () => {
       depositAmount.mul('10000'),
     )
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should fail to deposit if no eth given', async function () {
     const { router, weth, accounts, buttonToken } = await loadFixture(fixture)
-    const [user] = accounts;
+    const [user] = accounts
 
     const depositAmount = ethers.utils.parseEther('0')
     await expect(
       router.deposit(buttonToken.address, { value: depositAmount }),
     ).to.be.revertedWith('ButtonTokenWethRouter: No ETH supplied')
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should burn button tokens', async function () {
@@ -115,9 +115,9 @@ describe('ButtonTokenWethRouter', () => {
         .gt(ethers.utils.parseEther('0.24')),
     ).to.be.true
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should burn all button tokens', async function () {
@@ -149,47 +149,48 @@ describe('ButtonTokenWethRouter', () => {
         .gt(ethers.utils.parseEther('4.99')),
     ).to.be.true
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should fail to burn all if not approved', async function () {
     const { router, weth, accounts, buttonToken } = await loadFixture(fixture)
-    const [user] = accounts;
+    const [user] = accounts
 
     const depositAmount = ethers.utils.parseEther('5')
     await router.deposit(buttonToken.address, { value: depositAmount })
 
     await expect(router.burnAll(buttonToken.address)).to.be.reverted
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should fail to burn if not approved', async function () {
     const { router, weth, accounts, buttonToken } = await loadFixture(fixture)
-    const [user] = accounts;
+    const [user] = accounts
 
     const depositAmount = ethers.utils.parseEther('5')
     await router.deposit(buttonToken.address, { value: depositAmount })
 
     await expect(router.burn(buttonToken.address, depositAmount)).to.be.reverted
 
-    expect(await weth.balanceOf(router.address)).to.equal('0');
-    expect(await buttonToken.balanceOf(router.address)).to.equal('0');
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await weth.balanceOf(router.address)).to.equal('0')
+    expect(await buttonToken.balanceOf(router.address)).to.equal('0')
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 
   it('should send ETH directly to the router', async function () {
     const { router, accounts } = await loadFixture(fixture)
-    const [user] = accounts;
+    const [user] = accounts
 
     const depositAmount = ethers.utils.parseEther('5')
-    await expect(user.sendTransaction({ to: router.address, value: depositAmount }))
-      .to.be.revertedWith('ButtonTokenWethRouter: unexpected receive');
+    await expect(
+      user.sendTransaction({ to: router.address, value: depositAmount }),
+    ).to.be.revertedWith('ButtonTokenWethRouter: unexpected receive')
 
-    expect(await user.provider!.getBalance(router.address)).to.equal('0');
+    expect(await user.provider!.getBalance(router.address)).to.equal('0')
   })
 })


### PR DESCRIPTION
- updated ButtonToken contract to amend the return values on mint and burn methods
- unit tests were broken on main branch, so fixed those
- `yarn format` produced indentation changes, so committed those too

Regarding the unit tests, it seems it was not picked up before due to the version of node used (locally and for the github actions). You can see here that the error occurs, but the tests pass overall anyway: https://github.com/buttonwood-protocol/button-wrappers/runs/4172941454?check_suite_focus=true#step:7:1797

Brief experimentation suggests that it's specifically the version of node, rather than the modules installed against a version of node, that is the culprit. Versions 10 and 14 were tested and found to have this issue whilst 16 worked as intended.