### PR TITLE
Move price decimal handling to oracle interface level

### DIFF
--- a/contracts/ButtonToken.sol
+++ b/contracts/ButtonToken.sol
@@ -134,13 +134,11 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
     /// @param name_ The ERC20 name.
     /// @param symbol_ The ERC20 symbol.
     /// @param oracle_ The oracle which provides the underlying token price.
-    /// @param priceDecimals_ The decimal point precision of the oracle price.
     function initialize(
         address underlying_,
         string memory name_,
         string memory symbol_,
-        address oracle_,
-        uint256 priceDecimals_
+        address oracle_
     ) public override initializer {
         require(underlying_ != address(0), "ButtonToken: invalid underlying reference");
 
@@ -149,8 +147,6 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         underlying = underlying_;
         name = name_;
         symbol = symbol_;
-        priceBits = BITS_PER_UNDERLYING * (10 ** priceDecimals_);
-        maxPrice = maxPriceFromPriceDecimals(priceDecimals_);
 
         // MAX_UNDERLYING worth bits are 'pre-mined' to `address(0x)`
         // at the time of construction.
@@ -175,6 +171,10 @@ contract ButtonToken is IButtonToken, Initializable, OwnableUpgradeable {
         oracle = oracle_;
         (price, valid) = _queryPrice();
         require(valid, "ButtonToken: unable to fetch data from oracle");
+
+        uint256 priceDecimals = IOracle(oracle).priceDecimals();
+        priceBits = BITS_PER_UNDERLYING * (10 ** priceDecimals);
+        maxPrice = maxPriceFromPriceDecimals(priceDecimals);
 
         emit OracleUpdated(oracle);
         _rebase(price);

--- a/contracts/ButtonTokenFactory.sol
+++ b/contracts/ButtonTokenFactory.sol
@@ -30,12 +30,8 @@ contract ButtonTokenFactory is InstanceRegistry, IFactory {
         string memory name;
         string memory symbol;
         address oracle;
-        uint256 priceDecimals;
-        (underlying, name, symbol, oracle, priceDecimals) = abi.decode(
-            args,
-            (address, string, string, address, uint256)
-        );
-        return _create(underlying, name, symbol, oracle, priceDecimals);
+        (underlying, name, symbol, oracle) = abi.decode(args, (address, string, string, address));
+        return _create(underlying, name, symbol, oracle);
     }
 
     /// @dev Create and initialize an instance of the button token
@@ -43,10 +39,9 @@ contract ButtonTokenFactory is InstanceRegistry, IFactory {
         address underlying,
         string memory name,
         string memory symbol,
-        address oracle,
-        uint256 priceDecimals
+        address oracle
     ) external returns (address) {
-        return _create(underlying, name, symbol, oracle, priceDecimals);
+        return _create(underlying, name, symbol, oracle);
     }
 
     /**
@@ -57,14 +52,13 @@ contract ButtonTokenFactory is InstanceRegistry, IFactory {
         address underlying,
         string memory name,
         string memory symbol,
-        address oracle,
-        uint256 priceDecimals
+        address oracle
     ) private returns (address) {
         // Create instance
         address buttonToken = Clones.clone(template);
 
         // Initialize instance
-        IButtonToken(buttonToken).initialize(underlying, name, symbol, oracle, priceDecimals);
+        IButtonToken(buttonToken).initialize(underlying, name, symbol, oracle);
 
         // Transfer ownership to msg.sender
         OwnableUpgradeable(buttonToken).transferOwnership(msg.sender);

--- a/contracts/interfaces/IButtonToken.sol
+++ b/contracts/interfaces/IButtonToken.sol
@@ -25,7 +25,6 @@ interface IButtonToken is IButtonWrapper, IRebasingERC20 {
         address underlying_,
         string memory name_,
         string memory symbol_,
-        address oracle_,
-        uint256 initialPrice_
+        address oracle_
     ) external;
 }

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 interface IOracle {
-    function priceDecimals() external view returns (uint256 priceDecimals_);
+    function priceDecimals() external view returns (uint256);
 
     function getData() external view returns (uint256, bool);
 }

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 interface IOracle {
+    function priceDecimals() external view returns (uint256 priceDecimals_);
+
     function getData() external view returns (uint256, bool);
 }

--- a/contracts/mocks/MockOracle.sol
+++ b/contracts/mocks/MockOracle.sol
@@ -10,6 +10,10 @@ contract MockOracle is IOracle {
     uint256 private data;
     bool private success;
 
+    function priceDecimals() external view override returns (uint256 priceDecimals_) {
+        priceDecimals_ = 8;
+    }
+
     /**
      * Return mocked data returned by the oracle
      */

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -19,8 +19,12 @@ contract ChainlinkOracle is IOracle {
         stalenessThresholdSecs = _stalenessThresholdSecs;
     }
 
-    function priceDecimals() external view override returns (uint256 priceDecimals_) {
-        priceDecimals_ = oracle.decimals();
+    /**
+     * @notice Fetches the decimal precision used in the market price from chainlink
+     * @return priceDecimals_: Number of decimals in the price
+     */
+    function priceDecimals() external view override returns (uint256) {
+        return oracle.decimals();
     }
 
     /**

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -20,8 +20,16 @@ contract ChainlinkOracle is IOracle {
     }
 
     /**
+     * @notice Fetches the number of decimals the price values are formatted to
+     * @return priceDecimals_: The number of decimals
+     */
+    function priceDecimals() external view override returns (uint256 priceDecimals_) {
+        priceDecimals_ = oracle.decimals();
+    }
+
+    /**
      * @notice Fetches the latest market price from chainlink
-     * @return Value: Latest market price as an 8 decimal fixed point number.
+     * @return Value: Latest market price.
      *         valid: Boolean indicating an value was fetched successfully.
      */
     function getData() external view override returns (uint256, bool) {

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -19,10 +19,6 @@ contract ChainlinkOracle is IOracle {
         stalenessThresholdSecs = _stalenessThresholdSecs;
     }
 
-    /**
-     * @notice Fetches the number of decimals the price values are formatted to
-     * @return priceDecimals_: The number of decimals
-     */
     function priceDecimals() external view override returns (uint256 priceDecimals_) {
         priceDecimals_ = oracle.decimals();
     }

--- a/contracts/oracles/WamplOracle.sol
+++ b/contracts/oracles/WamplOracle.sol
@@ -41,8 +41,12 @@ contract WamplOracle is IOracle {
             int256(PRICE_DECIMALS);
     }
 
-    function priceDecimals() external view override returns (uint256 priceDecimals_) {
-        priceDecimals_ = PRICE_DECIMALS;
+    /**
+     * @notice Fetches the decimal precision used in the market price from chainlink
+     * @return priceDecimals_: Number of decimals in the price
+     */
+    function priceDecimals() external view override returns (uint256) {
+        return PRICE_DECIMALS;
     }
 
     /**

--- a/contracts/oracles/WamplOracle.sol
+++ b/contracts/oracles/WamplOracle.sol
@@ -42,6 +42,14 @@ contract WamplOracle is IOracle {
     }
 
     /**
+     * @notice Fetches the number of decimals the price values are formatted to
+     * @return priceDecimals_: The number of decimals
+     */
+    function priceDecimals() external view override returns (uint256 priceDecimals_) {
+        priceDecimals_ = PRICE_DECIMALS;
+    }
+
+    /**
      * @notice Fetches the latest market price from chainlink
      * @return Value: Latest market price as an 8 decimal fixed point number.
      *         valid: Boolean indicating an value was fetched successfully.

--- a/contracts/oracles/WamplOracle.sol
+++ b/contracts/oracles/WamplOracle.sol
@@ -41,10 +41,6 @@ contract WamplOracle is IOracle {
             int256(PRICE_DECIMALS);
     }
 
-    /**
-     * @notice Fetches the number of decimals the price values are formatted to
-     * @return priceDecimals_: The number of decimals
-     */
     function priceDecimals() external view override returns (uint256 priceDecimals_) {
         priceDecimals_ = PRICE_DECIMALS;
     }

--- a/test/simulation/precision.ts
+++ b/test/simulation/precision.ts
@@ -137,13 +137,7 @@ async function exec() {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   buttonToken = await buttonTokenFactory.connect(deployer).deploy()
 
-  buttonToken.initialize(
-    mockBTC.address,
-    'TEST',
-    'TEST',
-    mockOracle.address,
-    PRICE_DECIMALS,
-  )
+  buttonToken.initialize(mockBTC.address, 'TEST', 'TEST', mockOracle.address)
 
   await mockBTC
     .connect(deployer)

--- a/test/unit/ButtonToken.ts
+++ b/test/unit/ButtonToken.ts
@@ -56,13 +56,7 @@ async function setupContracts() {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   buttonToken = await buttonTokenFactory.connect(deployer).deploy()
 
-  buttonToken.initialize(
-    mockBTC.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    PRICE_DECIMALS,
-  )
+  buttonToken.initialize(mockBTC.address, NAME, SYMBOL, mockOracle.address)
 }
 
 function eqAprox(x: BigNumber, y: BigNumberish, diff: BigNumberish = '1') {

--- a/test/unit/ButtonTokenFactory.ts
+++ b/test/unit/ButtonTokenFactory.ts
@@ -30,11 +30,10 @@ async function createInstance(
   name: String,
   symbol: String,
   oracle: string,
-  priceDecimals: number,
 ) {
   const args = ethers.utils.defaultAbiCoder.encode(
-    ['address', 'string', 'string', 'address', 'uint256'],
-    [underlying, name, symbol, oracle, priceDecimals],
+    ['address', 'string', 'string', 'address'],
+    [underlying, name, symbol, oracle],
   )
   const instanceAddress = await factory.callStatic['create(bytes)'](args)
   await factory['create(bytes)'](args)
@@ -106,7 +105,6 @@ describe('ButtonToken:create', () => {
       'BUTTON-Bitcoin',
       'BUTTON-BTC',
       mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     expect(await bToken.owner()).to.eq(deployerAddress)
@@ -119,7 +117,6 @@ describe('ButtonToken:create', () => {
       'BUTTON-Bitcoin',
       'BUTTON-BTC',
       mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     expect(await bToken.underlying()).to.eq(mockBTC.address)
@@ -131,20 +128,13 @@ describe('ButtonToken:create', () => {
 
   it('Unpacked args should run with correct values', async function () {
     const instanceAddress = await factory.callStatic[
-      'create(address,string,string,address,uint256)'
-    ](
+      'create(address,string,string,address)'
+    ](mockBTC.address, 'BUTTON-Bitcoin', 'BUTTON-BTC', mockOracle.address)
+    await factory['create(address,string,string,address)'](
       mockBTC.address,
       'BUTTON-Bitcoin',
       'BUTTON-BTC',
       mockOracle.address,
-      PRICE_DECIMALS,
-    )
-    await factory['create(address,string,string,address,uint256)'](
-      mockBTC.address,
-      'BUTTON-Bitcoin',
-      'BUTTON-BTC',
-      mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     const bToken = (await ethers.getContractFactory('ButtonToken'))
@@ -160,7 +150,6 @@ describe('ButtonToken:create', () => {
       'BUTTON-Bitcoin',
       'BUTTON-BTC',
       mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     expect(await factory.instanceCount()).to.eq(1)
@@ -175,7 +164,6 @@ describe('ButtonToken:create', () => {
       'BUTTON-Bitcoin',
       'BUTTON-BTC',
       mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     expect(await mockBTC.balanceOf(deployerAddress)).to.eq(

--- a/test/unit/ButtonTokenWamplRouter.ts
+++ b/test/unit/ButtonTokenWamplRouter.ts
@@ -48,13 +48,7 @@ async function fixture(): Promise<TestContext> {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   const buttonToken = await buttonTokenFactory.deploy()
 
-  buttonToken.initialize(
-    wampl.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    PRICE_DECIMALS,
-  )
+  buttonToken.initialize(wampl.address, NAME, SYMBOL, mockOracle.address)
 
   const routerFactory = await ethers.getContractFactory(
     'ButtonTokenWamplRouter',
@@ -150,7 +144,6 @@ describe('ButtonTokenWamplRouter', () => {
       'BAD-BUTTON',
       'BTTN-BAD',
       mockOracle.address,
-      PRICE_DECIMALS,
     )
 
     const depositAmount = ethers.utils.parseUnits('10', 9)

--- a/test/unit/ButtonTokenWethRouter.ts
+++ b/test/unit/ButtonTokenWethRouter.ts
@@ -31,13 +31,7 @@ async function fixture(): Promise<TestContext> {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   const buttonToken = await buttonTokenFactory.deploy()
 
-  buttonToken.initialize(
-    weth.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    PRICE_DECIMALS,
-  )
+  buttonToken.initialize(weth.address, NAME, SYMBOL, mockOracle.address)
 
   const routerFactory = await ethers.getContractFactory('ButtonTokenWethRouter')
   const router = await routerFactory.deploy(weth.address)

--- a/test/unit/ButtonToken_button_wrapper.ts
+++ b/test/unit/ButtonToken_button_wrapper.ts
@@ -44,13 +44,7 @@ async function setupContracts() {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   buttonToken = await buttonTokenFactory.connect(deployer).deploy()
 
-  buttonToken.initialize(
-    mockBTC.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    PRICE_DECIMALS,
-  )
+  buttonToken.initialize(mockBTC.address, NAME, SYMBOL, mockOracle.address)
 }
 
 describe('ButtonToken:underlying', async () => {

--- a/test/unit/ButtonToken_erc20_behavior.ts
+++ b/test/unit/ButtonToken_erc20_behavior.ts
@@ -67,13 +67,7 @@ async function setupToken() {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   token = await buttonTokenFactory.connect(owner).deploy()
 
-  token.initialize(
-    mockBTC.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    ORACLE_DECIMALS,
-  )
+  token.initialize(mockBTC.address, NAME, SYMBOL, mockOracle.address)
 
   await mockBTC.connect(owner).mint(await owner.getAddress(), INITIAL_SUPPLY)
 

--- a/test/unit/ButtonToken_rebasing_erc20_behavior.ts
+++ b/test/unit/ButtonToken_rebasing_erc20_behavior.ts
@@ -34,13 +34,7 @@ async function setupToken() {
   const buttonTokenFactory = await ethers.getContractFactory('ButtonToken')
   token = await buttonTokenFactory.connect(owner).deploy()
 
-  await token.initialize(
-    mockBTC.address,
-    NAME,
-    SYMBOL,
-    mockOracle.address,
-    ORACLE_DECIMALS,
-  )
+  await token.initialize(mockBTC.address, NAME, SYMBOL, mockOracle.address)
 
   await mockBTC.connect(owner).mint(await owner.getAddress(), INITIAL_SUPPLY)
 

--- a/test/unit/ChainlinkOracle.ts
+++ b/test/unit/ChainlinkOracle.ts
@@ -66,8 +66,7 @@ describe('ChainlinkOracle', function () {
 
       expect(res.toString()).to.eq(data.toString())
       expect(success).to.eq(true)
-      expect(receipt.gasUsed.toString()).to.equal('78838')
-      expect(receipt.gasUsed.toString()).to.equal('78838')
+      expect(receipt.gasUsed.toString()).to.equal('78860')
     })
 
     it('should fail with stale data', async function () {
@@ -87,7 +86,7 @@ describe('ChainlinkOracle', function () {
 
       expect(res.toString()).to.eq(data.toString())
       expect(success).to.eq(false)
-      expect(receipt.gasUsed.toString()).to.equal('37038')
+      expect(receipt.gasUsed.toString()).to.equal('37060')
     })
   })
 })

--- a/test/unit/WamplOracle.ts
+++ b/test/unit/WamplOracle.ts
@@ -99,7 +99,7 @@ describe('WamplOracle', function () {
       // 1 WAMPL = ~5.9 AMPL, thus WamplOracle should return ~5.9e8
       expect(res.toString()).to.eq('592916430')
       expect(success).to.eq(true)
-      expect(receipt.gasUsed.toString()).to.equal('95823')
+      expect(receipt.gasUsed.toString()).to.equal('95845')
     })
 
     it('should fail with stale data', async function () {
@@ -139,7 +139,7 @@ describe('WamplOracle', function () {
 
       expect(res.toString()).to.eq('592916430')
       expect(success).to.eq(false)
-      expect(receipt.gasUsed.toString()).to.equal('75909')
+      expect(receipt.gasUsed.toString()).to.equal('75931')
     })
 
     it('handles different AMPL<->WAMPL conversion rates', async function () {
@@ -186,7 +186,7 @@ describe('WamplOracle', function () {
       // 1 WAMPL = ~5929 AMPL, thus WamplOracle should return ~5.9e11
       expect(res.toString()).to.eq('592916430444')
       expect(success).to.eq(true)
-      expect(receipt.gasUsed.toString()).to.equal('95823')
+      expect(receipt.gasUsed.toString()).to.equal('95845')
     })
 
     it('handles extreme oracle values', async function () {
@@ -228,7 +228,7 @@ describe('WamplOracle', function () {
       // The amplEth feed is non-zero but too small to remain so after scaled to 8 decimals
       expect(res.toString()).to.eq('0')
       expect(success).to.eq(true)
-      expect(receipt.gasUsed.toString()).to.equal('75923')
+      expect(receipt.gasUsed.toString()).to.equal('75945')
 
       // Set AMPL to be worth 1 ETH
       await expect(
@@ -249,7 +249,7 @@ describe('WamplOracle', function () {
       // There's just enough decimals to capture a non-zero value
       expect(res2.toString()).to.eq('5')
       expect(success2).to.eq(true)
-      expect(receipt2.gasUsed.toString()).to.equal('75923')
+      expect(receipt2.gasUsed.toString()).to.equal('75945')
     })
   })
 
@@ -319,6 +319,6 @@ describe('WamplOracle', function () {
     // 1 WAMPL = ~5.9 AMPL, thus WamplOracle should return ~5.9e8
     expect(res.toString()).to.eq('592916430')
     expect(success).to.eq(true)
-    expect(receipt.gasUsed.toString()).to.equal('95938')
+    expect(receipt.gasUsed.toString()).to.equal('95960')
   })
 })


### PR DESCRIPTION
## Changes
- moved oracle price decimals handling from being a ButtonToken initialization parameter to a property of the IOracle interface. This means it can be updated when the oracle is, and reduces the potential for human error to specify the wrong value during initialization