### PR TITLE
feat(ethx-oracle): adding ethx oracle for button-wrapping ethx from stader labs

### DIFF
--- a/contracts/interfaces/IStaderOracle.sol
+++ b/contracts/interfaces/IStaderOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @dev https://github.com/stader-labs/ethx/blob/mainnet_V0/contracts/interfaces/IStaderOracle.sol
+interface IStaderOracle {
+    /// @title ExchangeRate
+    /// @notice This struct holds data related to the exchange rate between ETH and ETHX.
+    struct ExchangeRate {
+        /// @notice The block number when the exchange rate was last updated.
+        uint256 reportingBlockNumber;
+        /// @notice The total balance of Ether (ETH) in the system.
+        uint256 totalETHBalance;
+        /// @notice The total supply of the liquid staking token (ETHX) in the system.
+        uint256 totalETHXSupply;
+    }
+
+    function getExchangeRate() external view returns (ExchangeRate memory);
+}

--- a/contracts/mocks/MockStaderOracle.sol
+++ b/contracts/mocks/MockStaderOracle.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+import {IStaderOracle} from "../interfaces/IStaderOracle.sol";
+
+contract MockStaderOracle is IStaderOracle {
+    uint256 public totalETHBalance = 10 ** 18;
+    uint256 public totalETHXSupply = 10 ** 18;
+
+    function setTotalETHBalance(uint256 totalETHBalance_) external {
+        totalETHBalance = totalETHBalance_;
+    }
+
+    function setTotalETHXSupply(uint256 totalETHXSupply_) external {
+        totalETHXSupply = totalETHXSupply_;
+    }
+
+    function getExchangeRate() external view override returns (ExchangeRate memory) {
+        return
+            ExchangeRate({
+                reportingBlockNumber: 0,
+                totalETHBalance: totalETHBalance,
+                totalETHXSupply: totalETHXSupply
+            });
+    }
+}

--- a/contracts/oracles/ETHxOracle.sol
+++ b/contracts/oracles/ETHxOracle.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {IOracle} from "../interfaces/IOracle.sol";
+import {IStaderOracle} from "../interfaces/IStaderOracle.sol";
+
+/**
+ * @title Stader Oracle
+ *
+ * @notice Provides an ETHx:ETH rate for a button wrapper to use
+ */
+contract ETHxOracle is IOracle {
+    /// @dev The output price has a 18 decimal point precision.
+    uint256 public constant PRICE_DECIMALS = 18;
+    // The address of the source Stader Labs oracle contract
+    IStaderOracle public immutable staderOracle;
+
+    constructor(IStaderOracle staderOracle_) {
+        staderOracle = staderOracle_;
+    }
+
+    /**
+     * @notice Fetches the decimal precision used in the market price from Stader oracle
+     * @return priceDecimals_: Number of decimals in the price
+     */
+    function priceDecimals() external pure override returns (uint256) {
+        return PRICE_DECIMALS;
+    }
+
+    /**
+     * @notice Fetches the latest ETHx:ETH exchange rate from ETHx contract.
+     * The returned value is specifically how much ETH is represented by 1e18 raw units of ETHx.
+     * @dev The returned value is considered to be always valid since it is derived directly from
+     *   the source token.
+     * @return Value: Latest market price as an `priceDecimals` decimal fixed point number.
+     *         valid: Boolean indicating an value was fetched successfully.
+     */
+    function getData() external view override returns (uint256, bool) {
+        IStaderOracle.ExchangeRate memory exchangeRate = staderOracle.getExchangeRate();
+        return (((10 ** 18) * exchangeRate.totalETHBalance) / exchangeRate.totalETHXSupply, true);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,6 +15,7 @@ export default {
   etherscan: {
     apiKey: {
       mainnet: process.env.ETHERSCAN_API_KEY,
+      goerli: process.env.ETHERSCAN_API_KEY,
       'base-goerli': process.env.BASE_API_KEY,
       'base-mainnet': process.env.BASE_API_KEY,
       avalanche: process.env.SNOWTRACE_API_KEY,

--- a/tasks/deployers/ethxOracle.ts
+++ b/tasks/deployers/ethxOracle.ts
@@ -1,0 +1,79 @@
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+
+const prefilledArgs: Record<string, TaskArguments> = {
+  'mainnet': {
+    staderoracle: '0xF64bAe65f6f2a5277571143A24FaaFDFC0C2a737',
+  },
+  'goerli': {
+    staderoracle: '0x22F8E700ff3912f3Caba5e039F6dfF1a24390E80',
+  }
+}
+
+task('deploy:ETHxOracle:prefilled', 'Verifies on etherscan').setAction(
+  async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported')
+    }
+
+    const { staderoracle } = prefilled;
+    console.log('staderOracle Address:', staderoracle)
+    await hre.run('deploy:ETHxOracle', { staderoracle })
+  },
+)
+
+task('deploy:ETHxOracle')
+  .addParam('staderoracle', 'the stader oracle address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { staderoracle } = args;
+    console.log('Signer', await (await hre.ethers.getSigners())[0].getAddress());
+    const ETHxOracle = await hre.ethers.getContractFactory('ETHxOracle');
+    const eTHxOracle = await ETHxOracle.deploy(staderoracle);
+    await eTHxOracle.deployed();
+    console.log(`ETHxOracle deployed to ${eTHxOracle.address}`);
+
+    try {
+      await hre.run('verify:verify', {
+        address: eTHxOracle.address,
+        constructorArguments: [staderoracle],
+      })
+    } catch (e) {
+      console.log('Unable to verify on etherscan', e)
+    }
+  })
+
+task('verify:ETHxOracle:prefilled', 'Verifies on etherscan')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported');
+    }
+    const { staderoracle } = prefilled;
+
+    const { address } = args;
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [staderoracle],
+    })
+  },
+)
+
+task('verify:ETHxOracle', 'Verifies on etherscan')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .addParam('staderoracle', 'the stader oracle address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { address, staderoracle } = args
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [staderoracle],
+    })
+  })

--- a/tasks/deployers/index.ts
+++ b/tasks/deployers/index.ts
@@ -1,10 +1,11 @@
-import './unbutton';
 import './button';
+import './ethxOracle';
 import './wethRouter';
 import './wamplOracle';
 import './mockERC20';
 import './mockOracle';
 import './savaxOracle';
 import './swETHOracle';
+import './unbutton';
 import './ButtonTokenWethRouter';
 import './ButtonTokenWamplRouter';

--- a/test/unit/ETHxOracle.ts
+++ b/test/unit/ETHxOracle.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import { ethers, waffle } from 'hardhat'
+
+async function mockedOracle() {
+  const [deployer, user] = await ethers.getSigners()
+  // deploy mocks
+  const mockStaderOracle = await (await ethers.getContractFactory('MockStaderOracle'))
+    .connect(deployer)
+    .deploy()
+  // deploy contract to test
+  const oracle = await (await ethers.getContractFactory('ETHxOracle'))
+    .connect(deployer)
+    .deploy(mockStaderOracle.address)
+  // need a contract with a non-view method that calls oracle.getData so we can gas test
+  const mockOracleDataFetcher = await (
+    await ethers.getContractFactory('MockOracleDataFetcher')
+  )
+    .connect(deployer)
+    .deploy(oracle.address)
+
+  return {
+    deployer,
+    user,
+    mockStaderOracle,
+    oracle,
+    mockOracleDataFetcher,
+  }
+}
+
+describe('ETHxOracle', function () {
+  describe('when sent ether', async function () {
+    it('should reject', async function () {
+      const { user, oracle } = await waffle.loadFixture(mockedOracle)
+      await expect(user.sendTransaction({ to: oracle.address, value: 1 })).to.be
+        .reverted
+    })
+  })
+
+  describe('Fetching data', async function () {
+    it('should succeed with fresh data', async function () {
+      const { user, mockStaderOracle, mockOracleDataFetcher } =
+        await waffle.loadFixture(mockedOracle)
+
+      await expect(
+        mockStaderOracle
+          .connect(user)
+          .setTotalETHXSupply(BigNumber.from('6413278131285121422182816')),
+      ).to.not.be.reverted
+      await expect(
+        mockStaderOracle
+          .connect(user)
+          .setTotalETHBalance(BigNumber.from('7091831834635293267033248')),
+      ).to.not.be.reverted
+
+      const tx = await mockOracleDataFetcher.connect(user).fetch()
+      const receipt = await tx.wait()
+      const [value, valid] = await mockOracleDataFetcher.getData()
+
+      // swETH denominated in ETH should be totalETH/totalSwETH
+      expect(value.toString()).to.eq('1105804502698871756')
+      expect(valid).to.eq(true)
+      expect(receipt.gasUsed.toString()).to.equal('78935')
+    })
+  })
+})


### PR DESCRIPTION
## Changes:
- Adding an ETHx oracle for creating a rebasing rETHx Token
- Reference: https://www.staderlabs.com/docs-v1/Ethereum/smart-contracts

## Tests:
- [x] Passes all unit tests
- [x] Deployed on goerli: https://goerli.etherscan.io/address/0xA06cea6Ae7323dAa054e1A1E358d8b6e6e70429B#code

## Reviewers:
@Fiddlekins 