### PR TITLE
feat(mev-eth): adding mev-eth oracle for buttoning mev-eth

### DIFF
--- a/contracts/interfaces/IMevETH.sol
+++ b/contracts/interfaces/IMevETH.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @dev https://github.com/manifoldfinance/mevETH2/blob/main/src/interfaces/IMevEth.sol
+interface IMevETH {
+    /**
+     * convertToAssets()
+     *
+     * @dev Converts a given number of shares to assets.
+     * @param shares The number of shares to convert.
+     * @return The number of assets.
+     */
+    function convertToAssets(uint256 shares) external view returns (uint256);
+}

--- a/contracts/mocks/MockMevETH.sol
+++ b/contracts/mocks/MockMevETH.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {IMevETH} from "../interfaces/IMevETH.sol";
+
+contract MockMevETH is IMevETH {
+    uint256 public totalShares = 10 ** 18;
+    uint256 public totalAssets = 10 ** 18;
+
+    function setTotalShares(uint256 totalShares_) external {
+        totalShares = totalShares_;
+    }
+
+    function setTotalAssets(uint256 totalAssets_) external {
+        totalAssets = totalAssets_;
+    }
+
+    function convertToAssets(uint256 shares) external view override returns (uint256) {
+        return (shares * totalAssets) / totalShares;
+    }
+}

--- a/contracts/oracles/MevEthOracle.sol
+++ b/contracts/oracles/MevEthOracle.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {IOracle} from "../interfaces/IOracle.sol";
+import {IMevETH} from "../interfaces/IMevETH.sol";
+
+/**
+ * @title mevETH Oracle
+ *
+ * @notice Provides a mevETH:ETH rate for a button wrapper to use
+ */
+contract MevEthOracle is IOracle {
+    /// @dev The output price has a 18 decimal point precision.
+    uint256 public constant PRICE_DECIMALS = 18;
+    // The address of the MevEth contract
+    IMevETH public immutable mevETH;
+
+    constructor(IMevETH mevETH_) {
+        mevETH = mevETH_;
+    }
+
+    /**
+     * @notice Fetches the decimal precision used in the market price
+     * @return priceDecimals_: Number of decimals in the price
+     */
+    function priceDecimals() external pure override returns (uint256) {
+        return PRICE_DECIMALS;
+    }
+
+    /**
+     * @notice Fetches the latest mevETH:ETH exchange rate from mevETH contract.
+     * The returned value is specifically how much ETH is represented by 1e18 raw units of mevETH.
+     * @dev The returned value is considered to be always valid since it is derived directly from
+     *   the source token.
+     * @return Value: Latest market price as an `priceDecimals` decimal fixed point number.
+     *         valid: Boolean indicating an value was fetched successfully.
+     */
+    function getData() external view override returns (uint256, bool) {
+        return (mevETH.convertToAssets(1e18), true);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,6 +15,7 @@ export default {
   etherscan: {
     apiKey: {
       mainnet: process.env.ETHERSCAN_API_KEY,
+      goerli: process.env.ETHERSCAN_API_KEY,
       'base-goerli': process.env.BASE_API_KEY,
       'base-mainnet': process.env.BASE_API_KEY,
       avalanche: process.env.SNOWTRACE_API_KEY,

--- a/tasks/deployers/index.ts
+++ b/tasks/deployers/index.ts
@@ -2,7 +2,7 @@ import './unbutton';
 import './button';
 import './wethRouter';
 import './wamplOracle';
-import './mevETHOracle';
+import './mevEthOracle';
 import './mockERC20';
 import './mockOracle';
 import './savaxOracle';

--- a/tasks/deployers/index.ts
+++ b/tasks/deployers/index.ts
@@ -2,6 +2,7 @@ import './unbutton';
 import './button';
 import './wethRouter';
 import './wamplOracle';
+import './mevETHOracle';
 import './mockERC20';
 import './mockOracle';
 import './savaxOracle';

--- a/tasks/deployers/mevEthOracle.ts
+++ b/tasks/deployers/mevEthOracle.ts
@@ -1,0 +1,79 @@
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+
+const prefilledArgs: Record<string, TaskArguments> = {
+  'mainnet': {
+    meveth: '0x24Ae2dA0f361AA4BE46b48EB19C91e02c5e4f27E',
+  },
+  'goerli': {
+    meveth: '0x',
+  }
+}
+
+task('deploy:MevEthOracle:prefilled', 'Verifies on etherscan').setAction(
+  async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported')
+    }
+
+    const { meveth } = prefilled;
+    console.log('MevEth Address:', meveth)
+    await hre.run('deploy:MevEthOracle', { meveth })
+  },
+)
+
+task('deploy:MevEthOracle')
+  .addParam('meveth', 'the mevETH token address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { meveth } = args;
+    console.log('Signer', await (await hre.ethers.getSigners())[0].getAddress());
+    const MevETHOracle = await hre.ethers.getContractFactory('MevEthOracle');
+    const mevETHOracle = await MevETHOracle.deploy(meveth);
+    await mevETHOracle.deployed();
+    console.log(`MevEthOracle deployed to ${mevETHOracle.address}`);
+
+    try {
+      await hre.run('verify:verify', {
+        address: mevETHOracle.address,
+        constructorArguments: [meveth],
+      })
+    } catch (e) {
+      console.log('Unable to verify on etherscan', e)
+    }
+  })
+
+task('verify:MevEthOracle:prefilled', 'Verifies on etherscan')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported');
+    }
+    const { meveth } = prefilled;
+
+    const { address } = args;
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [meveth],
+    })
+  },
+)
+
+task('verify:MevEthOracle', 'Verifies on etherscan')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .addParam('meveth', 'the mevETH token address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { address, meveth } = args
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [meveth],
+    })
+  })

--- a/test/unit/MevEthOracle.ts
+++ b/test/unit/MevEthOracle.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import { ethers, waffle } from 'hardhat'
+
+async function mockedOracle() {
+  const [deployer, user] = await ethers.getSigners()
+  // deploy mocks
+  const mockMevETH = await (await ethers.getContractFactory('MockMevETH'))
+    .connect(deployer)
+    .deploy()
+  // deploy contract to test
+  const oracle = await (await ethers.getContractFactory('MevEthOracle'))
+    .connect(deployer)
+    .deploy(mockMevETH.address)
+  // need a contract with a non-view method that calls oracle.getData so we can gas test
+  const mockOracleDataFetcher = await (
+    await ethers.getContractFactory('MockOracleDataFetcher')
+  )
+    .connect(deployer)
+    .deploy(oracle.address)
+
+  return {
+    deployer,
+    user,
+    mockMevETH,
+    oracle,
+    mockOracleDataFetcher,
+  }
+}
+
+describe('MevEthOracle', function () {
+  describe('when sent ether', async function () {
+    it('should reject', async function () {
+      const { user, oracle } = await waffle.loadFixture(mockedOracle)
+      await expect(user.sendTransaction({ to: oracle.address, value: 1 })).to.be
+        .reverted
+    })
+  })
+
+  describe('Fetching data', async function () {
+    it('should succeed with fresh data', async function () {
+      const { user, mockMevETH, mockOracleDataFetcher } =
+        await waffle.loadFixture(mockedOracle)
+
+      await expect(
+        mockMevETH
+          .connect(user)
+          .setTotalShares(BigNumber.from('6413278131285121422182816')),
+      ).to.not.be.reverted
+      await expect(
+        mockMevETH
+          .connect(user)
+          .setTotalAssets(BigNumber.from('7091831834635293267033248')),
+      ).to.not.be.reverted
+
+      const tx = await mockOracleDataFetcher.connect(user).fetch()
+      const receipt = await tx.wait()
+      const [value, valid] = await mockOracleDataFetcher.getData()
+
+      // mevETH denominated in ETH should be totalShares/totalAssets
+      expect(value.toString()).to.eq('1105804502698871756')
+      expect(valid).to.eq(true)
+      expect(receipt.gasUsed.toString()).to.equal('78601')
+    })
+  })
+})


### PR DESCRIPTION
## Changes:
- Adding an mevETH oracle for creating a rebasing rmevETH Token
- Reference:
    - https://docs.mev.io/docs/Core/MevEth
    - https://etherscan.io/address/0x24ae2da0f361aa4be46b48eb19c91e02c5e4f27e#code
    - https://github.com/manifoldfinance/mevETH2/blob/main/src/interfaces/IMevEth.sol

## Tests:
- [x] Passes all unit tests
- [ ] mevETH does not have a goeril instance

## Reviewers:
@Fiddlekins 