### PR TITLE
feat(ggavax): adding gg-avax-oracle for button-tokening gg-avax

### DIFF
--- a/contracts/interfaces/IggAVAX.sol
+++ b/contracts/interfaces/IggAVAX.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @dev https://snowtrace.io/address/0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f#code-43114#F1#L8
+interface IggAVAX {
+    function convertToAssets(uint256 shares) external view returns (uint256);
+}

--- a/contracts/mocks/MockGgAVAX.sol
+++ b/contracts/mocks/MockGgAVAX.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {IggAVAX} from "../interfaces/IggAVAX.sol";
+
+contract MockGgAVAX is IggAVAX {
+    uint256 public totalShares = 10 ** 18;
+    uint256 public totalAssets = 10 ** 18;
+
+    function setTotalShares(uint256 totalShares_) external {
+        totalShares = totalShares_;
+    }
+
+    function setTotalAssets(uint256 totalAssets_) external {
+        totalAssets = totalAssets_;
+    }
+
+    function convertToAssets(uint256 shares) external view override returns (uint256) {
+        return (shares * totalAssets) / totalShares;
+    }
+}

--- a/contracts/oracles/GgAVAXOracle.sol
+++ b/contracts/oracles/GgAVAXOracle.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {IOracle} from "../interfaces/IOracle.sol";
+import {IggAVAX} from "../interfaces/IggAVAX.sol";
+
+/**
+ * @title ggAVAX Oracle
+ *
+ * @notice Provides an ggAVAX:AVAX rate for a button wrapper to use
+ */
+contract GgAVAXOracle is IOracle {
+    /// @dev The output price has a 18 decimal point precision.
+    uint256 public constant PRICE_DECIMALS = 18;
+    // The address of the ggAVAX contract
+    IggAVAX public immutable ggAVAX;
+
+    constructor(IggAVAX ggAVAX_) {
+        ggAVAX = ggAVAX_;
+    }
+
+    /**
+     * @notice Fetches the decimal precision used in the market price
+     * @return priceDecimals_: Number of decimals in the price
+     */
+    function priceDecimals() external pure override returns (uint256) {
+        return PRICE_DECIMALS;
+    }
+
+    /**
+     * @notice Fetches the latest ggAVAX:AVAX exchange rate from ggAVAX contract.
+     * The returned value is specifically how much AVAX is represented by 1e18 raw units of ggAVAX.
+     * @dev The returned value is considered to be always valid since it is derived directly from
+     *   the source token.
+     * @return Value: Latest market price as an `priceDecimals` decimal fixed point number.
+     *         valid: Boolean indicating an value was fetched successfully.
+     */
+    function getData() external view override returns (uint256, bool) {
+        return (ggAVAX.convertToAssets(1e18), true);
+    }
+}

--- a/tasks/deployers/ggAVAXOracle.ts
+++ b/tasks/deployers/ggAVAXOracle.ts
@@ -1,0 +1,79 @@
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+
+const prefilledArgs: Record<string, TaskArguments> = {
+  'avalanche': {
+    ggavax: '0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3',
+  },
+  'fuji': {
+    ggavax: '0x',
+  }
+}
+
+task('deploy:GgAVAXOracle:prefilled', 'Verifies on snowtrace').setAction(
+  async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported')
+    }
+
+    const { ggavax } = prefilled;
+    console.log('ggAVAX Address:', ggavax)
+    await hre.run('deploy:GgAVAXOracle', { ggavax })
+  },
+)
+
+task('deploy:GgAVAXOracle')
+  .addParam('ggavax', 'the ggAVAX token address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { ggavax } = args;
+    console.log('Signer', await (await hre.ethers.getSigners())[0].getAddress());
+    const GgAVAXOracle = await hre.ethers.getContractFactory('GgAVAXOracle');
+    const ggAVAXOracle = await GgAVAXOracle.deploy(ggavax);
+    await ggAVAXOracle.deployed();
+    console.log(`GgAVAXOracle deployed to ${ggAVAXOracle.address}`);
+
+    try {
+      await hre.run('verify:verify', {
+        address: ggAVAXOracle.address,
+        constructorArguments: [ggavax],
+      })
+    } catch (e) {
+      console.log('Unable to verify on snowtrace', e)
+    }
+  })
+
+task('verify:GgAVAXOracle:prefilled', 'Verifies on snowtrace')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    console.log('chainId:', hre.network.config.chainId);
+    console.log('Network:', hre.network.name);
+
+    const prefilled = prefilledArgs[hre.network.name];
+    if (!prefilled) {
+      throw new Error('Network not supported');
+    }
+    const { ggavax } = prefilled;
+
+    const { address } = args;
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [ggavax],
+    })
+  },
+)
+
+task('verify:GgAVAXOracle', 'Verifies on snowtrace')
+  .addParam('address', 'the contract address', undefined, types.string, false)
+  .addParam('ggavax', 'the ggAVAX token address', undefined, types.string, false)
+  .setAction(async function (args: TaskArguments, hre) {
+    const { address, ggavax } = args
+
+    await hre.run('verify:verify', {
+      address,
+      constructorArguments: [ggavax],
+    })
+  })

--- a/tasks/deployers/index.ts
+++ b/tasks/deployers/index.ts
@@ -1,6 +1,7 @@
 import './ankrETHOracle';
 import './button';
 import './ethxOracle';
+import './ggAVAXOracle';
 import './wethRouter';
 import './wamplOracle';
 import './mevEthOracle';

--- a/test/unit/GgAVAXOracle.ts
+++ b/test/unit/GgAVAXOracle.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import { ethers, waffle } from 'hardhat'
+
+async function mockedOracle() {
+  const [deployer, user] = await ethers.getSigners()
+  // deploy mocks
+  const mockGgAVAX = await (await ethers.getContractFactory('MockGgAVAX'))
+    .connect(deployer)
+    .deploy()
+  // deploy contract to test
+  const oracle = await (await ethers.getContractFactory('GgAVAXOracle'))
+    .connect(deployer)
+    .deploy(mockGgAVAX.address)
+  // need a contract with a non-view method that calls oracle.getData so we can gas test
+  const mockOracleDataFetcher = await (
+    await ethers.getContractFactory('MockOracleDataFetcher')
+  )
+    .connect(deployer)
+    .deploy(oracle.address)
+
+  return {
+    deployer,
+    user,
+    mockGgAVAX,
+    oracle,
+    mockOracleDataFetcher,
+  }
+}
+
+describe('GgAvaxOracle', function () {
+  describe('when sent ether', async function () {
+    it('should reject', async function () {
+      const { user, oracle } = await waffle.loadFixture(mockedOracle)
+      await expect(user.sendTransaction({ to: oracle.address, value: 1 })).to.be
+        .reverted
+    })
+  })
+
+  describe('Fetching data', async function () {
+    it('should succeed with fresh data', async function () {
+      const { user, mockGgAVAX, mockOracleDataFetcher } =
+        await waffle.loadFixture(mockedOracle)
+
+      await expect(
+        mockGgAVAX
+          .connect(user)
+          .setTotalShares(BigNumber.from('6413278131285121422182816')),
+      ).to.not.be.reverted
+      await expect(
+        mockGgAVAX
+          .connect(user)
+          .setTotalAssets(BigNumber.from('7091831834635293267033248')),
+      ).to.not.be.reverted
+
+      const tx = await mockOracleDataFetcher.connect(user).fetch()
+      const receipt = await tx.wait()
+      const [value, valid] = await mockOracleDataFetcher.getData()
+
+      // ggAVAX denominated in AVAX should be totalShares/totalAssets
+      expect(value.toString()).to.eq('1105804502698871756')
+      expect(valid).to.eq(true)
+      expect(receipt.gasUsed.toString()).to.equal('78579')
+    })
+  })
+})


### PR DESCRIPTION
## Changes
- Adding an ggAVAX oracle for creating a rebasing rggAVAX Token
- Removing hard-coded gas-prices from hardhat config
- Reference:
  - https://docs.gogopool.com/design/gogopool-mechanics-overview/deployed-contract-addresses
  - https://github.com/multisig-labs/gogopool/blob/950873cf9195cad8c8f4b2e21ec148409d17915a/contracts/contract/tokens/TokenggAVAX.sol#L8
  - https://snowtrace.io/address/0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f#code-43114#F1#L8

## Testing :
 - [x] Passes all unit tests
 - [x] Successfully deploys on avax c-chain: https://snowtrace.io/address/0xcc880f05e4f869289b03FCbb62C47a7eAe58c313#code-43114

## Reviewers:
@Fiddlekins 
